### PR TITLE
introduce GuaranteeAllocation and GuaranteeOutcome

### DIFF
--- a/ts/nitro-types.ts
+++ b/ts/nitro-types.ts
@@ -1,14 +1,24 @@
 import { defaultAbiCoder } from "@ethersproject/abi";
-import { constants } from "ethers";
-import { Exit } from "./types";
+import { BytesLike, constants } from "ethers";
+import { Exit, Allocation, SingleAssetExit } from "./types";
 
-const MAGIC_VALUE_DENOTING_A_GUARANTEE =
+export const MAGIC_VALUE_DENOTING_A_GUARANTEE =
   "0x0000000000000000000000000000000000000001";
 // this will cause executeExit to revert, which is what we want for a guarantee
 // it should only work with a custom 'claim' operation
 // we avoid the magic value of the zero address, because that is already used by executeExit
 
-const guaranteeOutcome: Exit = [
+export type GuaranteeAllocation = Allocation & {
+  callTo: typeof MAGIC_VALUE_DENOTING_A_GUARANTEE;
+};
+
+export type SingleAssetGuaranteeOutcome = SingleAssetExit & {
+  allocations: GuaranteeAllocation[];
+};
+
+export type GuaranteeOutcome = SingleAssetGuaranteeOutcome[];
+
+const exampleGuaranteeOutcome1: GuaranteeOutcome = [
   {
     asset: constants.AddressZero,
     data: "0x",
@@ -17,18 +27,20 @@ const guaranteeOutcome: Exit = [
         destination: "0xjointchannel1",
         amount: "0xa",
         callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
-        data: encodeGuarantee("0xAlice", "0xHarry", "0xvirtualchannel1"),
+        data: encodeGuaranteeData("0xAlice", "0xHarry", "0xvirtualchannel1"),
       },
       {
         destination: "0xjointchannel2",
         amount: "0xa",
         callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
-        data: encodeGuarantee("0xAlice", "0xHarry", "0xvirtualchannel2"),
+        data: encodeGuaranteeData("0xAlice", "0xHarry", "0xvirtualchannel2"),
       },
     ],
   },
 ];
 
-function encodeGuarantee(...destinations: string[]) {
+const exampleGuaranteeOutcome2: Exit = exampleGuaranteeOutcome1; // GuaranteeOutcome is assignable to Exit
+
+function encodeGuaranteeData(...destinations: string[]): BytesLike {
   return defaultAbiCoder.encode(["address[]"], destinations);
 }


### PR DESCRIPTION
These TS types will be useful in constructing arguments to supply to the forthcoming `claim` function.


That function should have a signature something along the lines of: 

```solidity
    /**
     * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
     * @param initialGuaranteeOutcome the outcome containing at least one guarantee(s) which will be claimed for each asset.
     * @param initialHoldings initial quantity of each asset held on chain for the guarantor channel. Order matches that of initialGuaranteeOutcome.
     * @param targetChannel the index of the guarantee in the list of guarantees for the given asset -- equivalent to declaring a target channel
     * @param targetOutcome initial outcome stored on chain for the target channel.
     * @param indices list of list of indices expressing which destinations in the allocation should be paid out for each asset.

     */
    function claim(
        ExitFormat.SingleAssetExit[] memory initialGuaranteeOutcome,
        uint256[] memory initialHoldings,
        uint48 targetChannel,
        ExitFormat.SingleAssetExit[] memory initialTargetOutcome,
        uint48[][] memory exitRequest
    )
        public
        pure
        returns (
            ExitFormat.SingleAssetExit[] memory updatedTargetOutcome,
            uint256[] memory updatedHoldings,
            ExitFormat.SingleAssetExit[] memory exit
        )
```

 The method should `revert` if:
- the guarantee is not of the correct format (e.g. _does not_ use the magic constant)
- https://github.com/statechannels/exit-format/blob/81a99f570d7423064dddeadf0c711b01c6f0d528/ts/nitro-types.ts#L5-L6
- the targetOutcome is not of the correct format (e.g. _does_ use the magic constant)