### PR TITLE
sketch out a TokenManager

### DIFF
--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -19,7 +19,7 @@ library ExitFormat {
     // * an allocations array
     struct SingleAssetExit {
         address asset;
-        bytes data;
+        uint256 tokenType; // TODO We don't need 2**256 different values here
         Allocation[] allocations;
     }
 

--- a/contracts/Nitro.sol
+++ b/contracts/Nitro.sol
@@ -137,13 +137,13 @@ contract Nitro {
                     updatedTargetOutcome[assetIndex] = ExitFormat
                         .SingleAssetExit(
                         initialTargetOutcome[assetIndex].asset,
-                        initialTargetOutcome[assetIndex].data,
+                        initialTargetOutcome[assetIndex].tokenType,
                         targetAllocations
                     );
 
                     exit[assetIndex] = ExitFormat.SingleAssetExit(
                         initialTargetOutcome[assetIndex].asset,
-                        initialTargetOutcome[assetIndex].data,
+                        initialTargetOutcome[assetIndex].tokenType,
                         exitAllocations
                     );
                 }
@@ -219,12 +219,12 @@ contract Nitro {
             }
             updatedOutcome[i] = ExitFormat.SingleAssetExit(
                 initialOutcome[i].asset,
-                initialOutcome[i].data,
+                initialOutcome[i].tokenType,
                 initialAllocations
             );
             exit[i] = ExitFormat.SingleAssetExit(
                 initialOutcome[i].asset,
-                initialOutcome[i].data,
+                initialOutcome[i].tokenType,
                 exitAllocations
             );
         }

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -101,7 +101,7 @@ export function claim(
     }
     updatedTargetOutcome.push({
       asset: initialTargetOutcome[assetIndex].asset,
-      data: initialTargetOutcome[assetIndex].data,
+      tokenType: initialTargetOutcome[assetIndex].tokenType,
       allocations: updatedAllocations,
     });
     exit.push(singleAssetExit);

--- a/nitro-src/nitro-types.ts
+++ b/nitro-src/nitro-types.ts
@@ -22,7 +22,7 @@ const B_ADDRESS = "0x53484E75151D07FfD885159d4CF014B874cd2810";
 const exampleGuaranteeOutcome1: GuaranteeOutcome = [
   {
     asset: constants.AddressZero,
-    data: "0x",
+    tokenType: 0,
     allocations: [
       {
         destination: "0xjointchannel1",

--- a/nitro-src/transfer.ts
+++ b/nitro-src/transfer.ts
@@ -61,7 +61,7 @@ export function transfer(
     }
     updatedOutcome.push({
       asset: initialOutcome[i].asset,
-      data: initialOutcome[i].data,
+      tokenType: initialOutcome[i].tokenType,
       allocations: updatedAllocations,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface Allocation {
 
 export interface SingleAssetExit {
   asset: string; // an Ethereum address
-  data: BytesLike;
+  tokenType: BigNumberish;
   allocations: Allocation[];
 }
 

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -32,7 +32,7 @@ describe("ExitFormat (solidity)", function () {
     const exit: Exit = [
       {
         asset: "0x0000000000000000000000000000000000000000",
-        data: "0x",
+        tokenType: 0,
         allocations: [
           {
             destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",

--- a/test/exit-format-ts.test.ts
+++ b/test/exit-format-ts.test.ts
@@ -21,7 +21,7 @@ describe("ExitFormat (typescript)", function () {
     const exit: Exit = [
       {
         asset: "0x0000000000000000000000000000000000000000",
-        data: "0x",
+        tokenType: 0,
         allocations: [
           {
             destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -26,7 +26,7 @@ describe("claim (solidity)", function () {
   const initialOutcome: Exit = [
     {
       asset: ZERO_ADDRESS,
-      data: "0x",
+      tokenType: 0,
       allocations: [
         {
           destination: A_ADDRESS,
@@ -47,7 +47,7 @@ describe("claim (solidity)", function () {
   const guarantee: Exit = [
     {
       asset: ZERO_ADDRESS,
-      data: "0x",
+      tokenType: 0,
       allocations: [
         {
           destination: TARGET_CHANNEL_ADDRESS,

--- a/test/nitro/claim-ts.test.ts
+++ b/test/nitro/claim-ts.test.ts
@@ -18,7 +18,7 @@ describe("claim (typescript)", function () {
     const initialOutcome: Exit = [
       {
         asset: ZERO_ADDRESS,
-        data: "0x",
+        tokenType: 0,
         allocations: [
           {
             destination: A_ADDRESS,
@@ -39,7 +39,7 @@ describe("claim (typescript)", function () {
     const guarantee: Exit = [
       {
         asset: ZERO_ADDRESS,
-        data: "0x",
+        tokenType: 0,
         allocations: [
           {
             destination: TARGET_CHANNEL_ADDRESS,
@@ -112,7 +112,7 @@ describe("claim (typescript)", function () {
     const initialOutcome: Exit = [
       {
         asset: ZERO_ADDRESS,
-        data: "0x",
+        tokenType: 0,
         allocations: [
           {
             destination: A_ADDRESS,
@@ -133,7 +133,7 @@ describe("claim (typescript)", function () {
     const guarantee: Exit = [
       {
         asset: ZERO_ADDRESS,
-        data: "0x",
+        tokenType: 0,
         allocations: [
           {
             destination: ZERO_ADDRESS, // TODO: What should this be?

--- a/test/nitro/transfer-sol.test.ts
+++ b/test/nitro/transfer-sol.test.ts
@@ -17,7 +17,7 @@ describe("transfer (solidity)", function () {
   const initialOutcome: Exit = [
     {
       asset: "0x0000000000000000000000000000000000000000",
-      data: "0x",
+      tokenType: 0,
       allocations: [
         {
           destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",

--- a/test/nitro/transfer-ts.test.ts
+++ b/test/nitro/transfer-ts.test.ts
@@ -8,7 +8,7 @@ describe("transfer (typescript)", function () {
     const initialOutcome: Exit = [
       {
         asset: "0x0000000000000000000000000000000000000000",
-        data: "0x",
+        tokenType: 0,
         allocations: [
           {
             destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",


### PR DESCRIPTION
This defers the token switching logic to a separate library. We can add any other tokens besides ERC20s that have a different interface.

We could make that library upgradeable so as to support future tokens. 

TODO: 
- many test expectations need to be updated to follow the change from `bytes` to `uint256`.
- we can probably choose a type smaller than `uint256`