### PR TITLE
Cmk/bytes32destination

### DIFF
--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -83,7 +83,7 @@ library ExitFormat {
             for (uint256 j = 0; j < exit[i].allocations.length; j++) {
                 require(
                     _isAddress(exit[i].allocations[j].destination),
-                    "Destination is not an address"
+                    "Destination is not a zero-padded address"
                 );
                 address payable destination =
                     payable(

--- a/contracts/Nitro.sol
+++ b/contracts/Nitro.sol
@@ -11,9 +11,9 @@ contract Nitro {
     function decodeGuaranteeData(bytes memory data)
         internal
         pure
-        returns (address[] memory)
+        returns (bytes32[] memory)
     {
-        return abi.decode(data, (address[]));
+        return abi.decode(data, (bytes32[]));
     }
 
     /**
@@ -78,7 +78,7 @@ contract Nitro {
                 "Must be a valid guarantee with callTo set to MAGIC_VALUE_DENOTING_A_GUARANTEE"
             );
 
-            address[] memory destinations =
+            bytes32[] memory destinations =
                 decodeGuaranteeData(guarantees[targetChannelIndex].metadata);
 
             // Iterate through every destination in the guarantee's destinations

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -86,8 +86,8 @@ export function claim(
         if (surplus.lte(0)) break;
 
         if (
-          destinations[destinationIndex] ===
-          targetAllocations[targetAllocIndex].destination
+          destinations[destinationIndex].toLowerCase() ===
+          targetAllocations[targetAllocIndex].destination.toLowerCase()
         ) {
           // if we find it, compute new amount
           const affordsForDestination = min(

--- a/nitro-src/nitro-types.ts
+++ b/nitro-src/nitro-types.ts
@@ -43,9 +43,9 @@ const exampleGuaranteeOutcome1: GuaranteeOutcome = [
 const exampleGuaranteeOutcome2: Exit = exampleGuaranteeOutcome1; // GuaranteeOutcome is assignable to Exit
 
 export function encodeGuaranteeData(...destinations: string[]): BytesLike {
-  return defaultAbiCoder.encode(["address[]"], [destinations]);
+  return defaultAbiCoder.encode(["bytes32[]"], [destinations]);
 }
 
 export function decodeGuaranteeData(data: BytesLike): string[] {
-  return defaultAbiCoder.decode(["address[]"], data)[0];
+  return defaultAbiCoder.decode(["bytes32[]"], data)[0];
 }

--- a/nitro-src/nitro-types.ts
+++ b/nitro-src/nitro-types.ts
@@ -17,8 +17,8 @@ export type SingleAssetGuaranteeOutcome = SingleAssetExit & {
 };
 
 export type GuaranteeOutcome = SingleAssetGuaranteeOutcome[];
-const A_ADDRESS = "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f";
-const B_ADDRESS = "0x53484E75151D07FfD885159d4CF014B874cd2810";
+const A_ADDRESS = "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f";
+const B_ADDRESS = "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810";
 const exampleGuaranteeOutcome1: GuaranteeOutcome = [
   {
     asset: constants.AddressZero,

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -16,7 +16,7 @@ describe("ExitFormat (solidity)", function () {
 
   it("Can encode an allocation", async function () {
     const allocation: Allocation = {
-      destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+      destination: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
       amount: "0x01",
       callTo: "0x0000000000000000000000000000000000000000",
       metadata: "0x",
@@ -35,7 +35,7 @@ describe("ExitFormat (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
             amount: "0x01",
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -10,8 +10,8 @@ import { Nitro } from "../../typechain/Nitro";
 import { rehydrateExit } from "../test-helpers";
 
 const destinations = {
-  alice: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f".toLowerCase(),
-  bob: "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810".toLowerCase()
+  alice: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
+  bob: "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810"
 }
 
 describe("claim (solidity)", function () {
@@ -92,13 +92,13 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: destinations.alice,
+            destination: destinations.alice.toLowerCase(),
             amount: BigNumber.from("0x04"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: destinations.bob,
+            destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x00"), // TODO: It would be nice if these were stripped out
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -113,14 +113,14 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: destinations.bob,
+            destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x05"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
 
           {
-            destination: destinations.alice,
+            destination: destinations.alice.toLowerCase(),
             amount: BigNumber.from("0x01"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -160,13 +160,13 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: destinations.alice,
+            destination: destinations.alice.toLowerCase(),
             amount: BigNumber.from("0x05"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: destinations.bob,
+            destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x00"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -181,7 +181,7 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: destinations.bob,
+            destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x05"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -79,7 +79,7 @@ describe("claim (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(59090);
+    expect(gasEstimate.toNumber()).to.equal(58607);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(0)]);
 
@@ -147,7 +147,7 @@ describe("claim (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(57447);
+    expect(gasEstimate.toNumber()).to.equal(57016);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(1)]);
 

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -9,6 +9,11 @@ const { ethers } = require("hardhat");
 import { Nitro } from "../../typechain/Nitro";
 import { rehydrateExit } from "../test-helpers";
 
+const destinations = {
+  alice: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f".toLowerCase(),
+  bob: "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810".toLowerCase()
+}
+
 describe("claim (solidity)", function () {
   let nitro: Nitro;
 
@@ -19,9 +24,7 @@ describe("claim (solidity)", function () {
   });
 
   const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-  const A_ADDRESS = "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f".toLowerCase();
-  const B_ADDRESS = "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810".toLowerCase();
-  const TARGET_CHANNEL_ADDRESS = "0x000000000000000000000000080678731247781ff0d57c649b6d0ad1a0620df0".toLowerCase(); // At some point in the full claim operation, the outcome of this channel must be read and checked
+  const TARGET_CHANNEL_ADDRESS = "0x000000000000000000000000080678731247781ff0d57c649b6d0ad1a0620df0"; // At some point in the full claim operation, the outcome of this channel must be read and checked
 
   const initialOutcome: Exit = [
     {
@@ -29,13 +32,13 @@ describe("claim (solidity)", function () {
       metadata: "0x",
       allocations: [
         {
-          destination: A_ADDRESS,
+          destination: destinations.alice,
           amount: "0x05",
           callTo: ZERO_ADDRESS,
           metadata: "0x",
         },
         {
-          destination: B_ADDRESS,
+          destination: destinations.bob,
           amount: "0x05",
           callTo: ZERO_ADDRESS,
           metadata: "0x",
@@ -53,7 +56,7 @@ describe("claim (solidity)", function () {
           destination: TARGET_CHANNEL_ADDRESS,
           amount: "0x00",
           callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
-          metadata: encodeGuaranteeData(B_ADDRESS, A_ADDRESS),
+          metadata: encodeGuaranteeData(destinations.bob, destinations.alice),
         },
       ],
     },
@@ -89,13 +92,13 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: A_ADDRESS,
+            destination: destinations.alice,
             amount: BigNumber.from("0x04"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: B_ADDRESS,
+            destination: destinations.bob,
             amount: BigNumber.from("0x00"), // TODO: It would be nice if these were stripped out
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -110,14 +113,14 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: B_ADDRESS,
+            destination: destinations.bob,
             amount: BigNumber.from("0x05"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
 
           {
-            destination: A_ADDRESS,
+            destination: destinations.alice,
             amount: BigNumber.from("0x01"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -157,13 +160,13 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: A_ADDRESS,
+            destination: destinations.alice,
             amount: BigNumber.from("0x05"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: B_ADDRESS,
+            destination: destinations.bob,
             amount: BigNumber.from("0x00"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -178,7 +181,7 @@ describe("claim (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: B_ADDRESS,
+            destination: destinations.bob,
             amount: BigNumber.from("0x05"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -19,9 +19,9 @@ describe("claim (solidity)", function () {
   });
 
   const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-  const A_ADDRESS = "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f";
-  const B_ADDRESS = "0x53484E75151D07FfD885159d4CF014B874cd2810";
-  const TARGET_CHANNEL_ADDRESS = "0x080678731247781ff0d57c649b6d0ad1a0620df0"; // At some point in the full claim operation, the outcome of this channel must be read and checked
+  const A_ADDRESS = "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f".toLowerCase();
+  const B_ADDRESS = "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810".toLowerCase();
+  const TARGET_CHANNEL_ADDRESS = "0x000000000000000000000000080678731247781ff0d57c649b6d0ad1a0620df0".toLowerCase(); // At some point in the full claim operation, the outcome of this channel must be read and checked
 
   const initialOutcome: Exit = [
     {

--- a/test/nitro/claim-ts.test.ts
+++ b/test/nitro/claim-ts.test.ts
@@ -10,11 +10,11 @@ const { ethers } = require("hardhat");
 
 describe("claim (typescript)", function () {
   const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-  const A_ADDRESS = "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f";
-  const B_ADDRESS = "0x53484E75151D07FfD885159d4CF014B874cd2810";
-  const CHANNEL_1 = "0x080678731247781ff0d57c649b6d0ad1a0620df0"; // At some point in the full claim operation, the outcome of this channel must be read and checked
-  const CHANNEL_2 = "0x27592B3827907B54684E4f9da3d988263828893D"; // At some point in the full claim operation, the outcome of this channel must be read and checked
-  const I_ADDRESS = "0x7ab853663C531EaA080d84091AD0E0e985c688C7";
+  const A_ADDRESS = "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f";
+  const B_ADDRESS = "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810";
+  const CHANNEL_1 = "0x000000000000000000000000080678731247781ff0d57c649b6d0ad1a0620df0"; // At some point in the full claim operation, the outcome of this channel must be read and checked
+  const CHANNEL_2 = "0x00000000000000000000000027592B3827907B54684E4f9da3d988263828893D"; // At some point in the full claim operation, the outcome of this channel must be read and checked
+  const I_ADDRESS = "0x0000000000000000000000007ab853663C531EaA080d84091AD0E0e985c688C7";
 
   const createGuarantee = (
     guarantees: ["C1" | "C2", BigNumberish, Array<"A" | "B" | "I">][]

--- a/test/nitro/transfer-sol.test.ts
+++ b/test/nitro/transfer-sol.test.ts
@@ -6,6 +6,11 @@ const { ethers } = require("hardhat");
 import { Nitro } from "../../typechain/Nitro";
 import { rehydrateExit } from "../test-helpers";
 
+const destinations = {
+  alice: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f".toLowerCase(),
+  bob: "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810".toLowerCase()
+}
+
 describe("transfer (solidity)", function () {
   let nitro: Nitro;
 
@@ -21,13 +26,13 @@ describe("transfer (solidity)", function () {
       metadata: "0x",
       allocations: [
         {
-          destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+          destination: destinations.alice,
           amount: "0x05",
           callTo: "0x0000000000000000000000000000000000000000",
           metadata: "0x",
         },
         {
-          destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+          destination: destinations.bob,
           amount: "0x05",
           callTo: "0x0000000000000000000000000000000000000000",
           metadata: "0x",
@@ -52,7 +57,7 @@ describe("transfer (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(45876);
+    expect(gasEstimate.toNumber()).to.equal(45628);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(5)]);
 
@@ -62,13 +67,13 @@ describe("transfer (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: destinations.alice,
             amount: BigNumber.from("0x05"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: BigNumber.from("0x04"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -83,7 +88,7 @@ describe("transfer (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: BigNumber.from("0x01"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -109,7 +114,7 @@ describe("transfer (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(47404);
+    expect(gasEstimate.toNumber()).to.equal(47104);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(0)]);
 
@@ -119,13 +124,13 @@ describe("transfer (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: destinations.alice,
             amount: BigNumber.from("0x0"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: BigNumber.from("0x04"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -140,13 +145,13 @@ describe("transfer (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: destinations.alice,
             amount: BigNumber.from("0x5"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: BigNumber.from("0x01"),
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -165,13 +170,13 @@ describe("transfer (solidity)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: destinations.alice,
             amount: "0x05",
             callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
             metadata: "0x",
           },
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: "0x05",
             callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
             metadata: "0x",

--- a/test/nitro/transfer-ts.test.ts
+++ b/test/nitro/transfer-ts.test.ts
@@ -4,6 +4,11 @@ import { MAGIC_VALUE_DENOTING_A_GUARANTEE } from "../../nitro-src/nitro-types";
 import { transfer } from "../../nitro-src/transfer";
 import { Exit } from "../../src/types";
 
+const destinations = {
+  alice: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
+  bob: "0x00000000000000000000000053484E75151D07FfD885159d4CF014B874cd2810"
+}
+
 describe("transfer (typescript)", function () {
   it("Can transfer", async function () {
     const initialOutcome: Exit = [
@@ -12,13 +17,13 @@ describe("transfer (typescript)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: destinations.alice,
             amount: "0x05",
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: "0x05",
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -44,13 +49,13 @@ describe("transfer (typescript)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: destinations.alice,
             amount: "0x05",
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
           },
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: "0x04",
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -65,7 +70,7 @@ describe("transfer (typescript)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: "0x01",
             callTo: "0x0000000000000000000000000000000000000000",
             metadata: "0x",
@@ -84,13 +89,13 @@ describe("transfer (typescript)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination: destinations.alice,
             amount: "0x05",
             callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
             metadata: "0x",
           },
           {
-            destination: "0x53484E75151D07FfD885159d4CF014B874cd2810",
+            destination: destinations.bob,
             amount: "0x05",
             callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
             metadata: "0x",


### PR DESCRIPTION
Per #29, this replaces `address` destinations with `bytes32`, allowing for nitro style channel destinations as well as EOA destinations.

Biggest snag in implementation here is with respect to [EIP-55](https://eips.ethereum.org/EIPS/eip-55) address checksum behaving differently with the zero-padded destinations than with 'normal' addresses. Some smudging of test data and destination comparisons via `toLowerCase`.

:question: seeking comment: probably a test should exist that asserts the failure of `executeExit` when non-address destinations are supplied. Thoughts?