### PR TITLE
Replace `callTo` with `allocationType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,38 +60,38 @@ import { Exit, SingleAssetExit } from "@statechannels/exit-format";
 
 const ethExit: SingleAssetExit = {
   asset: "0x0000000000000000000000000000000000000000", // this implies the native token (e.g. ETH)
-  data: "0x",
+  metadata: "0x",
   allocations: [
     {
       destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f", // Alice
       amount: "0x05",
-      callTo: "0x0000000000000000000000000000000000000000", // a regular ETH transfer
-      data: "0x",
+      allocationType: AllocationType.simple, // a regular ETH transfer
+      metadata: "0x",
     },
     {
       destination: "0x0737369d5F8525D039038Da1EdBAC4C4f161b949", // Bob
       amount: "0x05",
-      callTo: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f", // this implies "call a WithdrawHelper"
-      data: "0x0123", /// ... with this calldata
+      allocationType: AllocationType.withdrawHelper, // call a WithdrawHelper
+      metadata: "0x0123", // at the address, and with the calldata, encoded within
     },
   ],
 };
 
 const daiExit: SingleAssetExit = {
-  asset: "0x6b175474e89094c44da98b954eedeac495271d0f ", // this implies DAI (an ERC20 token)
-  data: "0x",
+  asset: "0x6b175474e89094c44da98b954eedeac495271d0f", // this implies DAI (an ERC20 token)
+  metadata: "0x",
   allocations: [
     {
       destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f", // Alice
       amount: "0x05",
-      callTo: "0x0000000000000000000000000000000000000000", // a regular ERC20.transfer
-      data: "0x",
+      allocationType: AllocationType.simple, // a regular ERC20.transfer
+      metadata: "0x",
     },
     {
       destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f", // Bob
       amount: "0x05",
-      callTo: "0x0000000000000000000000000000000000000000", // a regular ERC20.transfer
-      data: "0x",
+      allocationType: AllocationType.simple, // a regular ERC20.transfer
+      metadata: "0x",
     },
   ],
 };

--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -28,15 +28,18 @@ library ExitFormat {
     // (which would make a material difference to the final state in the case of running out of gas or funds)
     // Allocations = Allocation[]
 
+    enum AllocationType {simple, withdrawHelper, guarantee}
+
     // An Allocation specifies
     // * a destination, referring either to an ethereum address or an application-specific identifier
     // * an amount of asset
+    // * an allocationType, which directs calling code on how to interpret the allocation
     // * custom metadata (optional field, can be zero bytes). This can be used flexibly by different protocols.
     struct Allocation {
         bytes32 destination;
         uint256 amount;
-        address callTo; // compatible with Vetor WithdrawHelper
-        bytes metadata; // compatible with Vetor WithdrawHelper
+        uint8 allocationType;
+        bytes metadata;
     }
 
     // We use underscore parentheses to denote an _encodedVariable_

--- a/contracts/Nitro.sol
+++ b/contracts/Nitro.sol
@@ -73,9 +73,9 @@ contract Nitro {
             uint48 exitRequestIndex = 0;
 
             require(
-                guarantees[targetChannelIndex].callTo ==
-                    0x0000000000000000000000000000000000000001,
-                "Must be a valid guarantee with callTo set to MAGIC_VALUE_DENOTING_A_GUARANTEE"
+                guarantees[targetChannelIndex].allocationType ==
+                    uint8(ExitFormat.AllocationType.guarantee),
+                "Must be a valid guarantee with allocationType set to ExitFormat.AllocationType.guarantee"
             );
 
             bytes32[] memory destinations =
@@ -124,7 +124,7 @@ contract Nitro {
                                 .Allocation(
                                 targetAllocations[targetAllocIndex].destination,
                                 affordsForDestination,
-                                targetAllocations[targetAllocIndex].callTo,
+                                targetAllocations[targetAllocIndex].allocationType,
                                 targetAllocations[targetAllocIndex].metadata
                             );
 
@@ -203,7 +203,9 @@ contract Nitro {
                     exitRequest[i].length == 0 ||
                     (k < exitRequest[i].length && exitRequest[i][k] == j)
                 ) {
-                    if (initialAllocations[j].callTo == address(1))
+                    if (initialAllocations[j].allocationType == uint8(
+                        ExitFormat.AllocationType.guarantee
+                    ))
                         revert("cannot transfer a guarantee");
                     updatedHoldings[i] -= affordsForDestination;
 
@@ -212,7 +214,7 @@ contract Nitro {
                     exitAllocations[k] = ExitFormat.Allocation(
                         initialAllocations[j].destination,
                         affordsForDestination,
-                        initialAllocations[j].callTo,
+                        initialAllocations[j].allocationType,
                         initialAllocations[j].metadata
                     );
                     ++k;

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -3,7 +3,7 @@ import {
   decodeGuaranteeData,
   MAGIC_VALUE_DENOTING_A_GUARANTEE,
 } from "./nitro-types";
-import { Exit, SingleAssetExit } from "../src/types";
+import { AllocationType, Exit, SingleAssetExit } from "../src/types";
 
 export function claim(
   initialGuaranteeOutcome: Exit,
@@ -40,7 +40,7 @@ export function claim(
     };
 
     if (
-      guarantees[targetChannelIndex].callTo !== MAGIC_VALUE_DENOTING_A_GUARANTEE
+      guarantees[targetChannelIndex].allocationType !== AllocationType.guarantee
     )
       throw Error;
 
@@ -128,7 +128,7 @@ export function claim(
             singleAssetExit.allocations.push({
               destination: targetAllocations[targetAllocIndex].destination,
               amount: affordsForDestination.toHexString(),
-              callTo: targetAllocations[targetAllocIndex].callTo,
+              allocationType: targetAllocations[targetAllocIndex].allocationType,
               metadata: targetAllocations[targetAllocIndex].metadata,
             });
 

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -1,8 +1,5 @@
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
-import {
-  decodeGuaranteeData,
-  MAGIC_VALUE_DENOTING_A_GUARANTEE,
-} from "./nitro-types";
+import { decodeGuaranteeData } from "./nitro-types";
 import { AllocationType, Exit, SingleAssetExit } from "../src/types";
 
 export function claim(
@@ -128,7 +125,8 @@ export function claim(
             singleAssetExit.allocations.push({
               destination: targetAllocations[targetAllocIndex].destination,
               amount: affordsForDestination.toHexString(),
-              allocationType: targetAllocations[targetAllocIndex].allocationType,
+              allocationType:
+                targetAllocations[targetAllocIndex].allocationType,
               metadata: targetAllocations[targetAllocIndex].metadata,
             });
 

--- a/nitro-src/nitro-types.ts
+++ b/nitro-src/nitro-types.ts
@@ -1,6 +1,6 @@
 import { defaultAbiCoder } from "@ethersproject/abi";
 import { BytesLike, constants } from "ethers";
-import { Exit, Allocation, SingleAssetExit } from "../src/types";
+import { Exit, Allocation, SingleAssetExit, AllocationType } from "../src/types";
 
 export const MAGIC_VALUE_DENOTING_A_GUARANTEE =
   "0x0000000000000000000000000000000000000001";
@@ -9,7 +9,7 @@ export const MAGIC_VALUE_DENOTING_A_GUARANTEE =
 // we avoid the magic value of the zero address, because that is already used by executeExit
 
 export type GuaranteeAllocation = Allocation & {
-  callTo: typeof MAGIC_VALUE_DENOTING_A_GUARANTEE;
+  allocationType: AllocationType.guarantee;
 };
 
 export type SingleAssetGuaranteeOutcome = SingleAssetExit & {
@@ -27,13 +27,13 @@ const exampleGuaranteeOutcome1: GuaranteeOutcome = [
       {
         destination: "0xjointchannel1",
         amount: "0xa",
-        callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+        allocationType: AllocationType.guarantee,
         metadata: encodeGuaranteeData(B_ADDRESS, A_ADDRESS),
       },
       {
         destination: "0xjointchannel2",
         amount: "0xa",
-        callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+        allocationType: AllocationType.guarantee,
         metadata: encodeGuaranteeData(A_ADDRESS, B_ADDRESS),
       },
     ],

--- a/nitro-src/nitro-types.ts
+++ b/nitro-src/nitro-types.ts
@@ -2,8 +2,6 @@ import { defaultAbiCoder } from "@ethersproject/abi";
 import { BytesLike, constants } from "ethers";
 import { Exit, Allocation, SingleAssetExit, AllocationType } from "../src/types";
 
-export const MAGIC_VALUE_DENOTING_A_GUARANTEE =
-  "0x0000000000000000000000000000000000000001";
 // this will cause executeExit to revert, which is what we want for a guarantee
 // it should only work with a custom 'claim' operation
 // we avoid the magic value of the zero address, because that is already used by executeExit

--- a/nitro-src/transfer.ts
+++ b/nitro-src/transfer.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
-import { Exit, SingleAssetExit } from "../src/types";
+import { AllocationType, Exit, SingleAssetExit } from "../src/types";
 import { MAGIC_VALUE_DENOTING_A_GUARANTEE } from "./nitro-types";
 
 /**
@@ -38,7 +38,7 @@ export function transfer(
         exitRequest[i].length == 0 ||
         (k < exitRequest[i].length && exitRequest[i][k] === j)
       ) {
-        if (initialAllocations[j].callTo == MAGIC_VALUE_DENOTING_A_GUARANTEE)
+        if (initialAllocations[j].allocationType == AllocationType.guarantee)
           throw Error("Cannot transfer a guarantee");
         updatedHoldings[i] = BigNumber.from(updatedHoldings[i]).sub(
           affordsForDestination
@@ -51,7 +51,7 @@ export function transfer(
         singleAssetExit.allocations.push({
           destination: initialAllocations[j].destination,
           amount: affordsForDestination.toHexString(),
-          callTo: initialAllocations[j].callTo,
+          allocationType: initialAllocations[j].allocationType,
           metadata: initialAllocations[j].metadata,
         });
         ++k;

--- a/nitro-src/transfer.ts
+++ b/nitro-src/transfer.ts
@@ -1,6 +1,5 @@
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
 import { AllocationType, Exit, SingleAssetExit } from "../src/types";
-import { MAGIC_VALUE_DENOTING_A_GUARANTEE } from "./nitro-types";
 
 /**
  * Extracts an exit from an initial outcome and an exit request

--- a/src/coders.ts
+++ b/src/coders.ts
@@ -3,7 +3,7 @@ import { Allocation, Exit } from "./types";
 
 export function encodeAllocations(allocation: Allocation) {
   return defaultAbiCoder.encode(
-    ["tuple(address destination, uint256 amount, address callTo, bytes metadata)"],
+    ["tuple(address destination, uint256 amount, uint8 allocationType, bytes metadata)"],
     [allocation]
   );
 }
@@ -22,7 +22,7 @@ export function encodeExit(exit: Exit) {
             components: [
               { name: "destination", type: "address" },
               { name: "amount", type: "uint256" },
-              { name: "callTo", type: "address" },
+              { name: "allocationType", type: "uint8" },
               { name: "metadata", type: "bytes" },
             ],
           } as ParamType,
@@ -47,6 +47,7 @@ export function decodeExit(_exit_: any) {
             components: [
               { name: "destination", type: "address" },
               { name: "amount", type: "uint256" },
+              { name: "allocationType", type: "uint8" },
               { name: "metadata", type: "bytes" },
             ],
           } as ParamType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,16 @@
 import { BigNumberish } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 
+export enum AllocationType {
+  simple,
+  withdrawHelper,
+  guarantee
+}
+
 export interface Allocation {
   destination: string; // an Ethereum address
   amount: BigNumberish;
-  callTo: string; // an Ethereum address
+  allocationType: BigNumberish;
   metadata: BytesLike;
 }
 

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
-import { Allocation, Exit } from "../src/types";
+import { Allocation, AllocationType, Exit } from "../src/types";
 import { TestConsumer } from "../typechain/TestConsumer";
 
 describe("ExitFormat (solidity)", function () {
@@ -18,7 +18,7 @@ describe("ExitFormat (solidity)", function () {
     const allocation: Allocation = {
       destination: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
       amount: "0x01",
-      callTo: "0x0000000000000000000000000000000000000000",
+      allocationType: AllocationType.simple,
       metadata: "0x",
     };
     const encodedAllocation = await testConsumer.encodeAllocation(allocation);
@@ -37,7 +37,7 @@ describe("ExitFormat (solidity)", function () {
           {
             destination: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
             amount: "0x01",
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],

--- a/test/exit-format-ts.test.ts
+++ b/test/exit-format-ts.test.ts
@@ -1,18 +1,17 @@
 const { expect } = require("chai");
 import { encodeAllocations, encodeExit } from "../src/coders";
-import { Allocation, Exit } from "../src/types";
+import { Allocation, AllocationType, Exit } from "../src/types";
 
 describe("ExitFormat (typescript)", function () {
   it("Can encode an allocation", async function () {
     const allocation: Allocation = {
       destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
       amount: "0x01",
-      callTo: "0x0000000000000000000000000000000000000000",
+      allocationType: AllocationType.simple,
       metadata: "0x",
     };
     const encodedAllocation = encodeAllocations(allocation);
     // console.log(`Encoded Allocation: ${encodedAllocation}`)
-
 
     expect(encodedAllocation).to.eq(
       "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000096f7123e3a80c9813ef50213aded0e4511cb820f0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000"
@@ -28,7 +27,7 @@ describe("ExitFormat (typescript)", function () {
           {
             destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
             amount: "0x01",
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -1,9 +1,6 @@
 const { expect } = require("chai");
 import { BigNumber } from "@ethersproject/bignumber";
-import {
-  encodeGuaranteeData,
-  MAGIC_VALUE_DENOTING_A_GUARANTEE,
-} from "../../nitro-src/nitro-types";
+import { encodeGuaranteeData } from "../../nitro-src/nitro-types";
 import { AllocationType, Exit } from "../../src/types";
 const { ethers } = require("hardhat");
 import { Nitro } from "../../typechain/Nitro";

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -79,7 +79,7 @@ describe("claim (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(58607);
+    expect(gasEstimate.toNumber()).to.equal(58310);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(0)]);
 
@@ -147,7 +147,7 @@ describe("claim (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(57016);
+    expect(gasEstimate.toNumber()).to.equal(56762);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(1)]);
 

--- a/test/nitro/claim-sol.test.ts
+++ b/test/nitro/claim-sol.test.ts
@@ -4,7 +4,7 @@ import {
   encodeGuaranteeData,
   MAGIC_VALUE_DENOTING_A_GUARANTEE,
 } from "../../nitro-src/nitro-types";
-import { Exit } from "../../src/types";
+import { AllocationType, Exit } from "../../src/types";
 const { ethers } = require("hardhat");
 import { Nitro } from "../../typechain/Nitro";
 import { rehydrateExit } from "../test-helpers";
@@ -34,13 +34,13 @@ describe("claim (solidity)", function () {
         {
           destination: destinations.alice,
           amount: "0x05",
-          callTo: ZERO_ADDRESS,
+          allocationType: AllocationType.simple,
           metadata: "0x",
         },
         {
           destination: destinations.bob,
           amount: "0x05",
-          callTo: ZERO_ADDRESS,
+          allocationType: AllocationType.simple,
           metadata: "0x",
         },
       ],
@@ -55,7 +55,7 @@ describe("claim (solidity)", function () {
         {
           destination: TARGET_CHANNEL_ADDRESS,
           amount: "0x00",
-          callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+          allocationType: AllocationType.guarantee,
           metadata: encodeGuaranteeData(destinations.bob, destinations.alice),
         },
       ],
@@ -94,13 +94,13 @@ describe("claim (solidity)", function () {
           {
             destination: destinations.alice.toLowerCase(),
             amount: BigNumber.from("0x04"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
           {
             destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x00"), // TODO: It would be nice if these were stripped out
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -115,14 +115,14 @@ describe("claim (solidity)", function () {
           {
             destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x05"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
 
           {
             destination: destinations.alice.toLowerCase(),
             amount: BigNumber.from("0x01"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -162,13 +162,13 @@ describe("claim (solidity)", function () {
           {
             destination: destinations.alice.toLowerCase(),
             amount: BigNumber.from("0x05"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
           {
             destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x00"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -183,7 +183,7 @@ describe("claim (solidity)", function () {
           {
             destination: destinations.bob.toLowerCase(),
             amount: BigNumber.from("0x05"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],

--- a/test/nitro/claim-ts.test.ts
+++ b/test/nitro/claim-ts.test.ts
@@ -5,7 +5,7 @@ import {
   encodeGuaranteeData,
   MAGIC_VALUE_DENOTING_A_GUARANTEE,
 } from "../../nitro-src/nitro-types";
-import { Exit } from "../../src/types";
+import { AllocationType, Exit } from "../../src/types";
 const { ethers } = require("hardhat");
 
 describe("claim (typescript)", function () {
@@ -36,7 +36,7 @@ describe("claim (typescript)", function () {
           return {
             destination: g[0] === "C1" ? CHANNEL_1 : CHANNEL_2,
             amount: BigNumber.from(g[1]).toHexString(),
-            callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+            allocationType: AllocationType.guarantee,
             metadata: encodeGuaranteeData(...guaranteeList),
           };
         }),
@@ -54,7 +54,7 @@ describe("claim (typescript)", function () {
           destination:
             a[0] === "A" ? A_ADDRESS : a[0] === "B" ? B_ADDRESS : I_ADDRESS,
           amount: BigNumber.from(a[1]).toHexString(),
-          callTo: ZERO_ADDRESS,
+          allocationType: AllocationType.simple,
           metadata: "0x",
         })),
       },

--- a/test/nitro/claim-ts.test.ts
+++ b/test/nitro/claim-ts.test.ts
@@ -1,10 +1,7 @@
 const { expect } = require("chai");
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
 import { claim } from "../../nitro-src/claim";
-import {
-  encodeGuaranteeData,
-  MAGIC_VALUE_DENOTING_A_GUARANTEE,
-} from "../../nitro-src/nitro-types";
+import { encodeGuaranteeData } from "../../nitro-src/nitro-types";
 import { AllocationType, Exit } from "../../src/types";
 const { ethers } = require("hardhat");
 

--- a/test/nitro/transfer-sol.test.ts
+++ b/test/nitro/transfer-sol.test.ts
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 import { BigNumber } from "@ethersproject/bignumber";
 import { MAGIC_VALUE_DENOTING_A_GUARANTEE } from "../../nitro-src/nitro-types";
-import { Exit } from "../../src/types";
+import { AllocationType, Exit } from "../../src/types";
 const { ethers } = require("hardhat");
 import { Nitro } from "../../typechain/Nitro";
 import { rehydrateExit } from "../test-helpers";
@@ -28,13 +28,13 @@ describe("transfer (solidity)", function () {
         {
           destination: destinations.alice,
           amount: "0x05",
-          callTo: "0x0000000000000000000000000000000000000000",
+          allocationType: AllocationType.simple,
           metadata: "0x",
         },
         {
           destination: destinations.bob,
           amount: "0x05",
-          callTo: "0x0000000000000000000000000000000000000000",
+          allocationType: AllocationType.simple,
           metadata: "0x",
         },
       ],
@@ -69,13 +69,13 @@ describe("transfer (solidity)", function () {
           {
             destination: destinations.alice,
             amount: BigNumber.from("0x05"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
           {
             destination: destinations.bob,
             amount: BigNumber.from("0x04"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -90,7 +90,7 @@ describe("transfer (solidity)", function () {
           {
             destination: destinations.bob,
             amount: BigNumber.from("0x01"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -126,13 +126,13 @@ describe("transfer (solidity)", function () {
           {
             destination: destinations.alice,
             amount: BigNumber.from("0x0"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
           {
             destination: destinations.bob,
             amount: BigNumber.from("0x04"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -147,13 +147,13 @@ describe("transfer (solidity)", function () {
           {
             destination: destinations.alice,
             amount: BigNumber.from("0x5"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
           {
             destination: destinations.bob,
             amount: BigNumber.from("0x01"),
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -172,13 +172,13 @@ describe("transfer (solidity)", function () {
           {
             destination: destinations.alice,
             amount: "0x05",
-            callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+            allocationType: AllocationType.guarantee,
             metadata: "0x",
           },
           {
             destination: destinations.bob,
             amount: "0x05",
-            callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+            allocationType: AllocationType.guarantee,
             metadata: "0x",
           },
         ],

--- a/test/nitro/transfer-sol.test.ts
+++ b/test/nitro/transfer-sol.test.ts
@@ -1,6 +1,5 @@
 const { expect } = require("chai");
 import { BigNumber } from "@ethersproject/bignumber";
-import { MAGIC_VALUE_DENOTING_A_GUARANTEE } from "../../nitro-src/nitro-types";
 import { AllocationType, Exit } from "../../src/types";
 const { ethers } = require("hardhat");
 import { Nitro } from "../../typechain/Nitro";

--- a/test/nitro/transfer-sol.test.ts
+++ b/test/nitro/transfer-sol.test.ts
@@ -56,7 +56,7 @@ describe("transfer (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(45628);
+    expect(gasEstimate.toNumber()).to.equal(45461);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(5)]);
 
@@ -113,7 +113,7 @@ describe("transfer (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(47104);
+    expect(gasEstimate.toNumber()).to.equal(46920);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(0)]);
 

--- a/test/nitro/transfer-ts.test.ts
+++ b/test/nitro/transfer-ts.test.ts
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 import { BigNumber } from "@ethersproject/bignumber";
 import { MAGIC_VALUE_DENOTING_A_GUARANTEE } from "../../nitro-src/nitro-types";
 import { transfer } from "../../nitro-src/transfer";
-import { Exit } from "../../src/types";
+import { AllocationType, Exit } from "../../src/types";
 
 const destinations = {
   alice: "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
@@ -19,13 +19,13 @@ describe("transfer (typescript)", function () {
           {
             destination: destinations.alice,
             amount: "0x05",
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
           {
             destination: destinations.bob,
             amount: "0x05",
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -51,13 +51,13 @@ describe("transfer (typescript)", function () {
           {
             destination: destinations.alice,
             amount: "0x05",
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
           {
             destination: destinations.bob,
             amount: "0x04",
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -72,7 +72,7 @@ describe("transfer (typescript)", function () {
           {
             destination: destinations.bob,
             amount: "0x01",
-            callTo: "0x0000000000000000000000000000000000000000",
+            allocationType: AllocationType.simple,
             metadata: "0x",
           },
         ],
@@ -91,13 +91,13 @@ describe("transfer (typescript)", function () {
           {
             destination: destinations.alice,
             amount: "0x05",
-            callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+            allocationType: AllocationType.guarantee,
             metadata: "0x",
           },
           {
             destination: destinations.bob,
             amount: "0x05",
-            callTo: MAGIC_VALUE_DENOTING_A_GUARANTEE,
+            allocationType: AllocationType.guarantee,
             metadata: "0x",
           },
         ],

--- a/test/nitro/transfer-ts.test.ts
+++ b/test/nitro/transfer-ts.test.ts
@@ -1,6 +1,5 @@
 const { expect } = require("chai");
 import { BigNumber } from "@ethersproject/bignumber";
-import { MAGIC_VALUE_DENOTING_A_GUARANTEE } from "../../nitro-src/nitro-types";
 import { transfer } from "../../nitro-src/transfer";
 import { AllocationType, Exit } from "../../src/types";
 

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -13,7 +13,7 @@ export function rehydrateExit(exitResult: Result) {
         object[key] = entry[key].map((allocation) => ({
           destination: allocation[0],
           amount: BigNumber.from(allocation[1]),
-          callTo: allocation[2],
+          allocationType: allocation[2],
           metadata: allocation[3],
         }));
       } else if (Number(key) !== Number(key)) object[key] = entry[key];


### PR DESCRIPTION
Re: #41 

This PR replaces the `callTo` address field with a `uint8` that serves as a switching flag that calling code can use to interpret each allocation.

Because we have the same sensibilities as the solidity language designers, our chosen `default` label for regular allocations was also a reserved word. I went with `simple`. Other options might be `vanilla`, `plain`, `regular`... ?