### PR TITLE
Fix over-claiming in typescript claim

### DIFF
--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -63,6 +63,11 @@ export function claim(
       };
     }
 
+    surplus = min(
+      surplus,
+      BigNumber.from(guarantees[targetChannelIndex].amount)
+    );
+
     let exitRequestIndex = 0;
 
     const destinations = decodeGuaranteeData(

--- a/test/nitro/claim-ts.test.ts
+++ b/test/nitro/claim-ts.test.ts
@@ -186,53 +186,6 @@ describe("claim (typescript)", function () {
     );
   });
 
-  it("guarantor_funding == target_funding < outcome_sum, pay out all via empty exit request", async function () {
-    const initialOutcome: Exit = createOutcome([
-      ["A", "0x05"],
-      ["B", "0x05"],
-      ["I", "0x0A"],
-    ]);
-
-    const guarantee: Exit = createGuarantee([["C1", "0x06", ["A", "I", "B"]]]);
-
-    const initialHoldings = [BigNumber.from(6)];
-    const exitRequest = [[]];
-
-    const claimResult = claim(
-      guarantee,
-      initialHoldings,
-      0,
-      initialOutcome,
-      exitRequest
-    );
-    const {
-      updatedHoldings,
-      updatedTargetOutcome,
-      exit,
-      updatedGuaranteeOutcome,
-    } = claimResult;
-
-    expect(updatedHoldings).to.deep.equal([BigNumber.from(0)]);
-
-    expect(updatedTargetOutcome).to.deep.equal(
-      createOutcome([
-        ["A", "0x00"],
-        ["B", "0x05"],
-        ["I", "0x09"],
-      ])
-    );
-
-    expect(exit).to.deep.equal(
-      createOutcome([
-        ["A", "0x05"],
-        ["I", "0x01"],
-      ])
-    );
-    expect(updatedGuaranteeOutcome).to.deep.equal(
-      createGuarantee([["C1", "0x00", ["A", "I", "B"]]])
-    );
-  });
-
   /**
    * Multiple channel per guarantee test
    */

--- a/test/nitro/claim-ts.test.ts
+++ b/test/nitro/claim-ts.test.ts
@@ -113,7 +113,7 @@ describe("claim (typescript)", function () {
     ]);
     const guarantee = createGuarantee([["C1", "0x06", ["A", "I", "B"]]]);
 
-    const initialHoldings = [BigNumber.from(1000)]; // Enough funds for everyone
+    const initialHoldings = [BigNumber.from(10)];
     const exitRequest = [[]];
 
     const {
@@ -123,13 +123,13 @@ describe("claim (typescript)", function () {
       updatedGuaranteeOutcome,
     } = claim(guarantee, initialHoldings, 0, initialOutcome, exitRequest);
 
-    expect(updatedHoldings).to.deep.equal([BigNumber.from(980)]);
+    expect(updatedHoldings).to.deep.equal([BigNumber.from(4)]);
 
     expect(updatedTargetOutcome).to.deep.equal(
       createOutcome([
         ["A", "0x00"],
-        ["B", "0x00"],
-        ["I", "0x00"],
+        ["B", "0x05"],
+        ["I", "0x09"],
       ])
     );
 
@@ -137,8 +137,7 @@ describe("claim (typescript)", function () {
     expect(exit).to.deep.equal(
       createOutcome([
         ["A", "0x05"],
-        ["I", "0x0A"],
-        ["B", "0x05"],
+        ["I", "0x01"],
       ])
     );
 


### PR DESCRIPTION
When claiming a guarantee `Gn` that is part of an outcome of guarantees `G0..Gn..Gz`, the total amount claimed is calculated as follows:
1. Sum total amounts needed for guarantees `G0` through `Gn-1`.
2. Subtract this amount from total asset held by the guarantor channel.

The amount that can be claimed is the smaller of the `Gn` amount and the amount calculated in step 2.