### PR TITLE
Refactor typescript claim

### DIFF
--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -61,7 +61,7 @@ export function claim(
       throw Error("Expected allocation type guarantee");
     }
 
-    // Any guarantees before this one have priority on the funds
+    // Any allocations before this one have priority on the funds
     // So we must account for that by reducing the surplus
     const guaranteesBeforeOurs = guaranteesForOneAsset.slice(
       0,

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -1,158 +1,197 @@
 import { BigNumber } from "@ethersproject/bignumber";
 import { decodeGuaranteeData } from "./nitro-types";
-import { AllocationType, Exit, SingleAssetExit } from "../src/types";
+import {
+  Allocation,
+  AllocationType,
+  Exit,
+  SingleAssetExit,
+} from "../src/types";
 import { constants } from "ethers";
 
+/**
+ * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
+ * @param guarantees the outcome containing at least one guarantee(s) which will be claimed for each asset.
+ * @param funds initial quantity of each asset held on chain for the guarantor channel. Order matches that of initialGuaranteeOutcome.
+ * @param targetChannelIndex the index of the guarantee in the list of guarantees for the given asset -- equivalent to declaring a target channel
+ * @param targetOutcome initial outcome stored on chain for the target channel.
+ * @param exitRequest list  of indices expressing which destinations in the allocation should be paid out for each asset.
+ */
 export function claim(
-  initialGuaranteeOutcome: Exit,
-  initialHoldings: BigNumber[],
+  guarantees: Exit,
+  funds: BigNumber[],
   targetChannelIndex: number,
-  initialTargetOutcome: Exit,
+  targetOutcome: Exit,
   exitRequest: number[][]
 ) {
-  if (initialTargetOutcome.length !== initialHoldings.length) throw Error;
-  const updatedTargetOutcome: Exit = [];
-  // Shallow-copy the holdings array as we will creating modified version.
-  const updatedHoldings = [...initialHoldings];
-  // Deep-copy the guaranteeOutcome as we will be creating a modified version.
-  const updatedGuaranteeOutcome: Exit = JSON.parse(
-    JSON.stringify(initialGuaranteeOutcome)
-  );
-  const exit: Exit = [];
+  if (targetOutcome.length !== funds.length)
+    throw Error("targetOutcome length must match funds length");
+
+  // Deep-copy as we will be creating a modified version.
+  const afterClaimGuarantee: Exit = JSON.parse(JSON.stringify(guarantees));
+  // Shallow-copy as we will creating modified version.
+  const afterClaimFunds = [...funds];
+
+  const afterClaimTargetOutcome: Exit = [];
+  const afterClaimExits: Exit = [];
 
   // Iterate through every asset
-  for (
-    let assetIndex = 0;
-    assetIndex < initialGuaranteeOutcome.length;
-    assetIndex++
-  ) {
-    const guarantees = initialGuaranteeOutcome[assetIndex].allocations;
-    const targetAllocations = initialTargetOutcome[assetIndex].allocations;
-
-    const updatedAllocations = targetAllocations.map((a) =>
-      JSON.parse(JSON.stringify(a))
-    ); // copy the allocations for mutation
+  for (let assetIndex = 0; assetIndex < guarantees.length; assetIndex++) {
+    const guarantee = guarantees[assetIndex].allocations;
+    const targetAllocations = targetOutcome[assetIndex].allocations;
 
     const singleAssetExit: SingleAssetExit = {
-      ...initialTargetOutcome[assetIndex],
+      ...targetOutcome[assetIndex],
       allocations: [], // start with an empty array
     };
 
     if (
-      guarantees[targetChannelIndex].allocationType !== AllocationType.guarantee
-    )
-      throw Error;
+      guarantee[targetChannelIndex].allocationType !== AllocationType.guarantee
+    ) {
+      throw Error("Expected allocation type guarantee");
+    }
 
-    let surplus = initialHoldings[assetIndex];
     // Any guarantees before this one have priority on the funds
     // So we must account for that by reducing the surplus
-    const guaranteesBeforeOurs = guarantees.slice(0, targetChannelIndex);
+    const guaranteesBeforeOurs = guarantee.slice(0, targetChannelIndex);
     const amountBeforeUs = guaranteesBeforeOurs
       .map((allocation) => BigNumber.from(allocation.amount))
       .reduce((sumSoFar, amount) => sumSoFar.add(amount), constants.Zero);
-    surplus = surplus.sub(amountBeforeUs);
-    // If there are not enough funds to fund the guarantee we return immediately
-    if (surplus.lte(0)) {
-      return {
-        updatedGuaranteeOutcome,
-        updatedHoldings,
-        updatedTargetOutcome,
-        exit,
-      };
+    const maximumAmountToPayOut = funds[assetIndex].sub(amountBeforeUs);
+
+    // If there are not enough funds to fund the guarantee, we skip the asset
+    if (maximumAmountToPayOut.lte(0)) {
+      continue;
     }
 
-    surplus = min(
-      surplus,
-      BigNumber.from(guarantees[targetChannelIndex].amount)
+    const fundsForOurGuarantee = min(
+      maximumAmountToPayOut,
+      BigNumber.from(guarantee[targetChannelIndex].amount)
     );
 
-    let exitRequestIndex = 0;
-
-    const destinations = decodeGuaranteeData(
-      guarantees[targetChannelIndex].metadata
-    );
     // Iterate through every destination in the guarantee's destinations
-    for (
-      let destinationIndex = 0;
-      destinationIndex < destinations.length;
-      destinationIndex++
-    ) {
-      if (surplus.isZero()) break;
-      for (
-        let targetAllocIndex = 0;
-        targetAllocIndex < targetAllocations.length;
-        targetAllocIndex++
-      ) {
-        if (surplus.lte(0)) break;
+    const {
+      updatedAllocations,
+      updatedGuaranteeAmount,
+      newExits,
+    } = claimOneGuarantee(
+      guarantee[targetChannelIndex],
+      targetAllocations,
+      fundsForOurGuarantee,
+      exitRequest,
+      assetIndex
+    );
+    const amountPaidOut = newExits
+      .map((allocation) => BigNumber.from(allocation.amount))
+      .reduce((prevVal, currentVal) => prevVal.add(currentVal));
+    afterClaimFunds[assetIndex] = afterClaimFunds[assetIndex].sub(
+      amountPaidOut
+    );
+    afterClaimGuarantee[assetIndex].allocations[
+      targetChannelIndex
+    ].amount = updatedGuaranteeAmount.toHexString();
 
+    afterClaimTargetOutcome.push({
+      asset: targetOutcome[assetIndex].asset,
+      metadata: targetOutcome[assetIndex].metadata,
+      allocations: updatedAllocations,
+    });
+
+    singleAssetExit.allocations = newExits;
+    afterClaimExits.push(singleAssetExit);
+  }
+
+  return {
+    updatedHoldings: afterClaimFunds,
+    updatedTargetOutcome: afterClaimTargetOutcome,
+    exit: afterClaimExits,
+    updatedGuaranteeOutcome: afterClaimGuarantee,
+  };
+}
+
+function claimOneGuarantee(
+  guarantee: Allocation,
+  targetAllocations: Allocation[],
+  fundingLeft: BigNumber,
+  exitRequest: number[][],
+  assetIndex: number
+): {
+  updatedAllocations: Allocation[];
+  updatedGuaranteeAmount: BigNumber;
+  newExits: Allocation[];
+} {
+  let updatedAllocations = [...targetAllocations];
+  let updatedGuaranteeAmount = BigNumber.from(guarantee.amount);
+  const newExits: Allocation[] = [];
+  const destinations = decodeGuaranteeData(guarantee.metadata);
+  let exitRequestIndex = 0;
+
+  /**
+   * The outer for loop iterates through destinations in the guarantee
+   */
+  for (
+    let destinationIndex = 0;
+    destinationIndex < destinations.length;
+    destinationIndex++
+  ) {
+    // TODO: why do we check for zero here but for less than zero below?
+    if (fundingLeft.isZero()) break;
+
+    /**
+     * The inner loop iterates through the target allocations.
+     */
+    for (
+      let targetAllocIndex = 0;
+      targetAllocIndex < targetAllocations.length;
+      targetAllocIndex++
+    ) {
+      if (fundingLeft.lte(0)) break;
+
+      if (
+        destinations[destinationIndex].toLowerCase() ===
+        targetAllocations[targetAllocIndex].destination.toLowerCase()
+      ) {
+        // if we find it, compute new amount
+        const affordsForDestination = min(
+          BigNumber.from(targetAllocations[targetAllocIndex].amount),
+          fundingLeft
+        );
+
+        // only if specified in supplied exitRequests, or we if we are doing "all"
         if (
-          destinations[destinationIndex].toLowerCase() ===
-          targetAllocations[targetAllocIndex].destination.toLowerCase()
+          exitRequest.length === 0 ||
+          exitRequest[assetIndex].length === 0 ||
+          (exitRequestIndex < exitRequest[assetIndex].length &&
+            exitRequest[assetIndex][exitRequestIndex] === targetAllocIndex)
         ) {
-          // if we find it, compute new amount
-          const affordsForDestination = min(
-            BigNumber.from(targetAllocations[targetAllocIndex].amount),
-            surplus
+          // Update the holdings and allocation
+          updatedAllocations[targetAllocIndex].amount = BigNumber.from(
+            targetAllocations[targetAllocIndex].amount
+          )
+            .sub(affordsForDestination)
+            .toHexString();
+
+          updatedGuaranteeAmount = updatedGuaranteeAmount.sub(
+            affordsForDestination
           );
 
-          // only if specified in supplied exitRequests, or we if we are doing "all"
-          if (
-            exitRequest.length === 0 ||
-            exitRequest[assetIndex].length === 0 ||
-            (exitRequestIndex < exitRequest[assetIndex].length &&
-              exitRequest[assetIndex][exitRequestIndex] === targetAllocIndex)
-          ) {
-            // Update the holdings and allocation
-            updatedHoldings[assetIndex] = BigNumber.from(
-              updatedHoldings[assetIndex]
-            ).sub(affordsForDestination);
-            updatedAllocations[targetAllocIndex].amount = BigNumber.from(
-              targetAllocations[targetAllocIndex].amount
-            )
-              .sub(affordsForDestination)
-              .toHexString();
+          newExits.push({
+            destination: targetAllocations[targetAllocIndex].destination,
+            amount: affordsForDestination.toHexString(),
+            allocationType: targetAllocations[targetAllocIndex].allocationType,
+            metadata: targetAllocations[targetAllocIndex].metadata,
+          });
 
-            const currentGuaranteeAmount = BigNumber.from(
-              updatedGuaranteeOutcome[assetIndex].allocations[
-                targetChannelIndex
-              ].amount
-            );
-
-            // Update the guarantee
-            updatedGuaranteeOutcome[assetIndex].allocations[
-              targetChannelIndex
-            ].amount = currentGuaranteeAmount
-              .sub(min(currentGuaranteeAmount, affordsForDestination))
-              .toHexString();
-
-            singleAssetExit.allocations.push({
-              destination: targetAllocations[targetAllocIndex].destination,
-              amount: affordsForDestination.toHexString(),
-              allocationType:
-                targetAllocations[targetAllocIndex].allocationType,
-              metadata: targetAllocations[targetAllocIndex].metadata,
-            });
-
-            ++exitRequestIndex;
-          } else {
-          }
+          exitRequestIndex++;
           // decrease surplus by the current amount regardless of hitting a specified exitRequest
-          surplus = surplus.sub(affordsForDestination);
+          fundingLeft = fundingLeft.sub(affordsForDestination);
         }
       }
     }
-    updatedTargetOutcome.push({
-      asset: initialTargetOutcome[assetIndex].asset,
-      metadata: initialTargetOutcome[assetIndex].metadata,
-      allocations: updatedAllocations,
-    });
-    exit.push(singleAssetExit);
   }
   return {
-    updatedHoldings,
-    updatedTargetOutcome,
-    exit,
-    updatedGuaranteeOutcome,
+    updatedAllocations,
+    updatedGuaranteeAmount,
+    newExits,
   };
 }
 

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -7,6 +7,7 @@ import {
   SingleAssetExit,
 } from "../src/types";
 import { constants } from "ethers";
+import _ from "lodash";
 
 /**
  * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
@@ -27,10 +28,9 @@ export function claim(
     throw Error("targetOutcome length must match funds length");
   }
 
-  // Deep-copy as we will mutating this object.
-  const afterClaimGuarantee: Exit = JSON.parse(JSON.stringify(guarantees));
-  // Shallow-copy as we will assinging new values to indeces.
-  const afterClaimHoldings = [...holdings];
+  // Deep-copy as we will mutating these objects.
+  const afterClaimGuarantee: Exit = _.cloneDeep(guarantees);
+  const afterClaimHoldings = _.cloneDeep(holdings);
 
   const afterClaimTargetOutcome: Exit = [];
   const afterClaimExits: Exit = [];
@@ -121,7 +121,7 @@ function claimOneGuaranteeForOneAsset(
   afterClaimGuaranteeAmount: BigNumber;
   newExits: Allocation[];
 } {
-  let afterClaimAllocations = [...targetAllocations];
+  let afterClaimAllocations = _.cloneDeep(targetAllocations);
   let afterClaimGuaranteeAmount = BigNumber.from(guarantee.amount);
   const newExits: Allocation[] = [];
   const destinations = decodeGuaranteeData(guarantee.metadata);
@@ -191,6 +191,7 @@ function claimOneGuaranteeForOneAsset(
       }
     }
   }
+
   return {
     afterClaimAllocations,
     afterClaimGuaranteeAmount,

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -169,7 +169,6 @@ function claimOneGuaranteeForOneAsset(
         // only if specified in supplied exitRequests, or we if we are doing "all"
         if (
           exitRequest.length === 0 ||
-          exitRequest.length === 0 ||
           (exitRequestIndex < exitRequest.length &&
             exitRequest[exitRequestIndex] === targetAllocIndex)
         ) {

--- a/nitro-src/claim.ts
+++ b/nitro-src/claim.ts
@@ -10,12 +10,21 @@ import { constants } from "ethers";
 import _ from "lodash";
 
 /**
+ * Note about the inputs.
+ * exitRequest is a 2 dimensional array.
+ * - The first index enumerates assets.
+ * - The second index enumerates destinations.
+ * This means that the target channel must have the following characteristics.
+ * - Every asset must list every destination.
+ * - The destination order must be consistent across assets.
+ */
+/**
  * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
  * @param guarantees the outcome containing at least one guarantee(s) which will be claimed for each asset.
  * @param holdings initial quantity of each asset held on chain for the guarantor channel. Order matches that of initialGuaranteeOutcome.
  * @param targetChannelIndex the index of the guarantee in the list of guarantees for the given asset -- equivalent to declaring a target channel
  * @param targetOutcome initial outcome stored on chain for the target channel.
- * @param exitRequest list  of indices expressing which destinations in the allocation should be paid out for each asset.
+ * @param exitRequest list of indices expressing which destinations in the allocation should be paid out for each asset.
  */
 export function claim(
   guarantees: Exit,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tsconfig/recommended": "^1.0.1",
     "@typechain/ethers-v5": "^6.0.5",
     "@types/chai": "^4.2.17",
+    "@types/lodash": "^4.14.171",
     "@types/mocha": "^8.2.2",
     "@types/node": "^15.0.0",
     "chai": "^4.3.4",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.1.0",
-    "ethers": "^5.1.4"
+    "ethers": "^5.1.4",
+    "lodash": "^4.17.21"
   }
 }

--- a/test/nitro/claim-ts.test.ts
+++ b/test/nitro/claim-ts.test.ts
@@ -169,7 +169,6 @@ describe("claim (typescript)", function () {
       ])
     );
 
-    // Since there are lots of funds everything gets funded
     expect(exit).to.deep.equal(
       createOutcome([
         ["A", "0x05"],
@@ -182,7 +181,7 @@ describe("claim (typescript)", function () {
     );
   });
 
-  it("guarantor_funding == target_funding < outcome_sum, pay out all via no exit requests", async function () {
+  it("guarantor_funding == target_funding < outcome_sum", async function () {
     const initialOutcome: Exit = createOutcome([
       ["A", "0x05"],
       ["B", "0x05"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,11 @@
     "@types/abstract-leveldown" "*"
     "@types/node" "*"
 
+"@types/lodash@^4.14.171":
+  version "4.14.171"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
+  integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
+
 "@types/lru-cache@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
@@ -4810,7 +4815,7 @@ lodash@4.17.20:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
I had a bit of trouble understanding the typescript implementation of`claim`. The function is 154 lines long and has quite a few levels of nesting. I refactored the function to align with my understanding. My approach has been:
- Tease the function apart into 2 functions.
- Rename variables.
- Use map/reduce instead of loops for some of the calculations.

One of the test cases has been enhanced as well.