### PR TITLE
Relax solidity version pragma

### DIFF
--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.4;
+pragma solidity >=0.7.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
+}
 
 // Ideally this would be imported from @connect/vector-withdraw-helpers
 // And the interface would match this one (note WithdrawData calldata wd has become bytes calldata cD)

--- a/contracts/Nitro.sol
+++ b/contracts/Nitro.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.4;
+pragma solidity >=0.7.0;
 
 import "./ExitFormat.sol";
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.1.0",
     "ethers": "^5.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,11 +507,6 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.1.0.tgz#baec89a7f5f73e3d8ea582a78f1980134b605375"
-  integrity sha512-TihZitscnaHNcZgXGj9zDLDyCqjziytB4tMCwXq0XimfWkAjBYyk5/pOsDbbwcavhlc79HhpTEpQcrMnPVa1mw==
-
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
We would like this library to be useable in a wide range of consuming projects -- including our own!

Currently, the solidity compiler version pragma prevents use of this library with _any_ version of solidity other than 0.8.4. We should not be this opinionated about the compiler version.

Relaxing the range of versions will allow us to use the exit format in nitro protocol.

The openzeppelin erc20 interface we use is also problematic because it cannot be compiled with solidity 0.7. This seems pretty strange to me, since the interface surely predates 0.7 and doesn't need to change. Anyway... I just inlined the bit of the interface we need.

We could think about reducing the minimum version even further. 