### PR TITLE
Introduce _computeNewAllocation function

### DIFF
--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -10,7 +10,7 @@ interface IERC20 {
         returns (bool);
 }
 
-// Ideally this would be imported from @connect/vector-withdraw-helpers
+// Ideally this would be imported from @connext/vector-withdraw-helpers
 // And the interface would match this one (note WithdrawData calldata wd has become bytes calldata cD)
 interface WithdrawHelper {
     function execute(bytes calldata cD, uint256 actualAmount) external;

--- a/contracts/Nitro.sol
+++ b/contracts/Nitro.sol
@@ -219,15 +219,16 @@ contract Nitro {
         }
     }
 
+    // massage payouts into an allocations array
     function convertPayoutsToExitAllocations(
         ExitFormat.Allocation[] memory initialAllocations,
         uint256[] memory payouts,
         uint48[] memory indices
     ) public pure returns (ExitFormat.Allocation[] memory exitAllocations) {
-        // massage output so it is an "exit" again
+        // TODO require indices to be of the right length
         uint256 k = 0;
         exitAllocations = new ExitFormat.Allocation[](
-            initialAllocations.length
+            indices.length == 0 ? initialAllocations.length : indices.length
         );
         // loop over allocations
         for (uint256 i = 0; i < initialAllocations.length; i++) {
@@ -237,15 +238,18 @@ contract Nitro {
                 (indices.length == 0) ||
                 ((k < indices.length) && (indices[k] == i))
             ) {
+                uint256 m = indices.length == 0 ? i : k;
                 // unless the allocation was targetted in indices (a slice of an exitRequest)
                 // in which case we defer to the payouts
-                payout = payouts[i];
+                payout = payouts[m];
+                ++k;
+                exitAllocations[m].destination = initialAllocations[i]
+                    .destination;
+                exitAllocations[m].amount = payout;
+                exitAllocations[m].allocationType = initialAllocations[i]
+                    .allocationType;
+                exitAllocations[m].metadata = initialAllocations[i].metadata;
             }
-            exitAllocations[i].destination = initialAllocations[i].destination;
-            exitAllocations[i].amount = payout;
-            exitAllocations[i].allocationType = initialAllocations[i]
-                .allocationType;
-            exitAllocations[i].metadata = initialAllocations[i].metadata;
         }
     }
 

--- a/contracts/Nitro.sol
+++ b/contracts/Nitro.sol
@@ -280,8 +280,10 @@ contract Nitro {
 
         // loop over allocations and decrease surplus
         for (uint256 i = 0; i < allocations.length; i++) {
-            // copy destination part
+            // copy destination, allocationType and metadata parts
             newAllocations[i].destination = allocations[i].destination;
+            newAllocations[i].allocationType = allocations[i].allocationType;
+            newAllocations[i].metadata = allocations[i].metadata;
             // compute new amount part
             uint256 affordsForDestination = min(allocations[i].amount, surplus);
             if (

--- a/contracts/Nitro.sol
+++ b/contracts/Nitro.sol
@@ -192,7 +192,7 @@ contract Nitro {
                 uint256[] memory payouts,
                 uint256 totalPayouts
             ) =
-                _computeNewAllocation(
+                _computeNewAllocations(
                     initialHoldings[assetIndex],
                     initialOutcome[assetIndex].allocations,
                     exitRequest[assetIndex]
@@ -253,7 +253,7 @@ contract Nitro {
         }
     }
 
-    function _computeNewAllocation(
+    function _computeNewAllocations(
         uint256 initialHoldings,
         ExitFormat.Allocation[] memory allocations,
         uint48[] memory indices

--- a/nitro-src/nitro-types.ts
+++ b/nitro-src/nitro-types.ts
@@ -7,12 +7,8 @@ import {
   AllocationType,
 } from "../src/types";
 
-// this will cause executeExit to revert, which is what we want for a guarantee
-// it should only work with a custom 'claim' operation
-// we avoid the magic value of the zero address, because that is already used by executeExit
-
 export type GuaranteeAllocation = Allocation & {
-  allocationType: AllocationType.guarantee;
+  allocationType: AllocationType.guarantee; // this should cause executeExit to revert, which is what we want for a guarantee
 };
 
 export type SingleAssetGuaranteeOutcome = SingleAssetExit & {

--- a/nitro-src/transfer.ts
+++ b/nitro-src/transfer.ts
@@ -1,5 +1,10 @@
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
-import { AllocationType, Exit, SingleAssetExit } from "../src/types";
+import {
+  Allocation,
+  AllocationType,
+  Exit,
+  SingleAssetExit,
+} from "../src/types";
 
 /**
  * Extracts an exit from an initial outcome and an exit request
@@ -14,63 +19,129 @@ export function transfer(
 ) {
   if (initialOutcome.length !== initialHoldings.length) throw Error;
   const updatedOutcome: Exit = [];
-  let updatedHoldings = initialHoldings;
+  let updatedHoldings = initialHoldings.map(BigNumber.from);
   const exit: Exit = [];
 
-  for (let i = 0; i < initialOutcome.length; i++) {
-    // i indexes assets
-    const initialAllocations = initialOutcome[i].allocations; // unpacking
-    const updatedAllocations = [...initialAllocations]; // copy the allocations for mutation
-    let surplus = BigNumber.from(initialHoldings[i]); //
-    const singleAssetExit: SingleAssetExit = {
-      ...initialOutcome[i],
-      allocations: [], // start with an empty array
-    };
-    let k = 0; // k is an index for this asset's exitRequest
-    for (let j = 0; j < initialAllocations.length; j++) {
-      // j indexes allocations for this asset
-      const affordsForDestination = min(
-        BigNumber.from(initialAllocations[j].amount),
-        surplus
-      );
-      if (
-        exitRequest[i].length == 0 ||
-        (k < exitRequest[i].length && exitRequest[i][k] === j)
-      ) {
-        if (initialAllocations[j].allocationType == AllocationType.guarantee)
-          throw Error("Cannot transfer a guarantee");
-        updatedHoldings[i] = BigNumber.from(updatedHoldings[i]).sub(
-          affordsForDestination
-        );
-        updatedAllocations[j].amount = BigNumber.from(
-          initialAllocations[j].amount
-        )
-          .sub(affordsForDestination)
-          .toHexString();
-        singleAssetExit.allocations.push({
-          destination: initialAllocations[j].destination,
-          amount: affordsForDestination.toHexString(),
-          allocationType: initialAllocations[j].allocationType,
-          metadata: initialAllocations[j].metadata,
-        });
-        ++k;
-      } else {
-        updatedAllocations[j].amount = BigNumber.from(
-          initialAllocations[j].amount
-        ).toHexString();
-      }
-      surplus = surplus.sub(affordsForDestination);
-    }
-    updatedOutcome.push({
-      asset: initialOutcome[i].asset,
-      metadata: initialOutcome[i].metadata,
-      allocations: updatedAllocations,
-    });
+  // loop over assets
+  for (let assetIndex = 0; assetIndex < initialOutcome.length; assetIndex++) {
+    const {
+      newAllocations,
+      allocatesOnlyZeros,
+      payouts,
+      totalPayouts,
+    } = computeNewAllocations(
+      BigNumber.from(initialHoldings[assetIndex]).toHexString(),
+      initialOutcome[assetIndex].allocations,
+      exitRequest[assetIndex]
+    );
 
-    exit.push(singleAssetExit);
+    updatedHoldings[assetIndex] = updatedHoldings[assetIndex].sub(totalPayouts);
+    updatedOutcome[assetIndex] = {
+      asset: initialOutcome[assetIndex].asset,
+      metadata: initialOutcome[assetIndex].metadata,
+      allocations: newAllocations,
+    };
+
+    const exitAllocations: Allocation[] = convertPayoutsToExitAllocations(
+      initialOutcome[assetIndex].allocations,
+      payouts,
+      exitRequest[assetIndex]
+    );
+
+    exit[assetIndex] = {
+      asset: initialOutcome[assetIndex].asset,
+      metadata: initialOutcome[assetIndex].metadata,
+      allocations: exitAllocations,
+    };
   }
 
   return { updatedHoldings, updatedOutcome, exit };
+}
+
+function convertPayoutsToExitAllocations(
+  initialAllocations: Allocation[],
+  payouts: string[],
+  indices: number[]
+) {
+  let k = 0;
+  const exitAllocations: Allocation[] = [];
+  // loop over allocations
+  for (let i = 0; i < initialAllocations.length; i++) {
+    if (indices.length == 0 || (k < indices.length && indices[k] == i)) {
+      const m = indices.length === 0 ? i : k;
+      const payout = payouts[m];
+      ++k;
+      exitAllocations.push({
+        destination: initialAllocations[i].destination,
+        amount: payout,
+        allocationType: initialAllocations[i].allocationType,
+        metadata: initialAllocations[i].metadata,
+      });
+    }
+  }
+  return exitAllocations;
+}
+
+/**
+ *
+ * Emulates solidity code. TODO replace with PureEVM implementation?
+ * @param initialHoldings
+ * @param allocation
+ * @param indices
+ */
+export function computeNewAllocations(
+  initialHoldings: string,
+  allocations: Allocation[], // we must index this with a JS number that is less than 2**32 - 1
+  indices: number[]
+): {
+  newAllocations: Allocation[];
+  allocatesOnlyZeros: boolean;
+  payouts: string[];
+  totalPayouts: string;
+} {
+  const payouts: string[] = Array(
+    indices.length > 0 ? indices.length : allocations.length
+  ).fill(BigNumber.from(0).toHexString());
+  let totalPayouts = BigNumber.from(0);
+  const newAllocations: Allocation[] = [];
+  let allocatesOnlyZeros = true;
+  let surplus = BigNumber.from(initialHoldings);
+  let k = 0;
+
+  for (let i = 0; i < allocations.length; i++) {
+    newAllocations.push({
+      destination: allocations[i].destination,
+      allocationType: allocations[i].allocationType,
+      metadata: allocations[i].metadata,
+      amount: BigNumber.from(0).toHexString(),
+    });
+    const affordsForDestination = min(
+      BigNumber.from(allocations[i].amount),
+      surplus
+    );
+    if (indices.length == 0 || (k < indices.length && indices[k] === i)) {
+      if (allocations[i].allocationType === AllocationType.guarantee)
+        throw Error("cannot transfer a guarantee");
+      newAllocations[i].amount = BigNumber.from(allocations[i].amount)
+        .sub(affordsForDestination)
+        .toHexString();
+      payouts[k] = affordsForDestination.toHexString();
+      totalPayouts = totalPayouts.add(affordsForDestination);
+      ++k;
+    } else {
+      newAllocations[i].amount = allocations[i].amount;
+    }
+    if (!BigNumber.from(newAllocations[i].amount).isZero())
+      allocatesOnlyZeros = false;
+    surplus = surplus.sub(affordsForDestination);
+  }
+
+  return {
+    newAllocations,
+    allocatesOnlyZeros,
+    payouts,
+    totalPayouts: totalPayouts.toHexString(),
+  };
 }
 
 function min(a: BigNumber, b: BigNumber) {

--- a/test/nitro/transfer-sol.test.ts
+++ b/test/nitro/transfer-sol.test.ts
@@ -94,7 +94,7 @@ describe("transfer (solidity)", function () {
       },
     ]);
 
-    expect(gasEstimate.toNumber()).to.equal(48024);
+    expect(gasEstimate.toNumber()).to.equal(48584);
   });
 
   it("Can transfer with an emptpy exitRequest", async function () {
@@ -157,7 +157,7 @@ describe("transfer (solidity)", function () {
       },
     ]);
 
-    expect(gasEstimate.toNumber()).to.equal(49824);
+    expect(gasEstimate.toNumber()).to.equal(50384);
   });
 
   it("Reverts if the initialOutcome is a guarantee", async function () {

--- a/test/nitro/transfer-sol.test.ts
+++ b/test/nitro/transfer-sol.test.ts
@@ -56,8 +56,6 @@ describe("transfer (solidity)", function () {
       exitRequest
     );
 
-    expect(gasEstimate.toNumber()).to.equal(45461);
-
     expect(updatedHoldings).to.deep.equal([BigNumber.from(5)]);
 
     expect(rehydrateExit(updatedOutcome)).to.deep.equal([
@@ -95,6 +93,8 @@ describe("transfer (solidity)", function () {
         ],
       },
     ]);
+
+    expect(gasEstimate.toNumber()).to.equal(48024);
   });
 
   it("Can transfer with an emptpy exitRequest", async function () {
@@ -112,8 +112,6 @@ describe("transfer (solidity)", function () {
       initialHoldings,
       exitRequest
     );
-
-    expect(gasEstimate.toNumber()).to.equal(46920);
 
     expect(updatedHoldings).to.deep.equal([BigNumber.from(0)]);
 
@@ -158,6 +156,8 @@ describe("transfer (solidity)", function () {
         ],
       },
     ]);
+
+    expect(gasEstimate.toNumber()).to.equal(49824);
   });
 
   it("Reverts if the initialOutcome is a guarantee", async function () {


### PR DESCRIPTION
Towards #48 .

This PR adds a pure  `_computeNewAllocation` function. This has the same name, and very close to the same interface, as the function we use in `nitro-protocol`. 

This function replaces the bulk of the body of the `transfer` function in this repo. The other additional code is just glue to preserve the current `transfer` API (of this repo) for the tests to hit. It's worth saying that that API should in general play second fiddle to what we are doing over in `nitro-protocol`** -- although there might be some nice ideas in this repo that we can preserve longer term.  The reason for that preference is 1) that nitro-protocol has more tests and thinking behind it and 2) that we will shortly resolve the two different APIs anyway (see #47). Once there is only one API to think about, we can consider changing it again if we want to.

One such idea is that the output of the `_computeNewAllocation` function might want to be an `ExitFormat.Allocation[]` rather than a `uint256[] payouts`. If we want to do that, the (glue code) `convertPayoutsToExitAllocations` (also added here) will be not be necessary. The reason we might want to do that is to support the use of `executeExit` code that lives in this repo, and will continue to do so, and that does things like handle connext's `WithdrawHelpers`.

On the other hand, the current API of looping over all assets is i) inflexible and ii) at odds with `nitro-protocol`. So I think we should consider that ear-marked for deprecating.

When the time comes that these changes go back into `nitro-protocol`, and we integrate the exit format there, it will be much easier given the refactor here with this  `_computeNewAllocation` helper function. 

TODO:
- [x] the analogous change to the typescript version of `transfer`.
- [ ] the same thing for `claim` (future PR)

** the current API in `nitro-protocol` is to either allow i) all assets to be paid out to all destinations or ii) for an asset to be specified up front, along with an `indices` array that selects only some of the destinations to pay out. 


