### PR TITLE
convert some addresses to bytes32

### DIFF
--- a/src/coders.ts
+++ b/src/coders.ts
@@ -4,7 +4,7 @@ import { Allocation, Exit } from "./types";
 export function encodeAllocations(allocation: Allocation) {
   return defaultAbiCoder.encode(
     [
-      "tuple(address destination, uint256 amount, uint8 allocationType, bytes metadata)",
+      "tuple(bytes32 destination, uint256 amount, uint8 allocationType, bytes metadata)",
     ],
     [allocation]
   );
@@ -22,7 +22,7 @@ export function encodeExit(exit: Exit) {
             type: "tuple[]",
             name: "allocations",
             components: [
-              { name: "destination", type: "address" },
+              { name: "destination", type: "bytes32" },
               { name: "amount", type: "uint256" },
               { name: "allocationType", type: "uint8" },
               { name: "metadata", type: "bytes" },
@@ -47,7 +47,7 @@ export function decodeExit(_exit_: any) {
             type: "tuple[]",
             name: "allocations",
             components: [
-              { name: "destination", type: "address" },
+              { name: "destination", type: "bytes32" },
               { name: "amount", type: "uint256" },
               { name: "allocationType", type: "uint8" },
               { name: "metadata", type: "bytes" },

--- a/test/exit-format-ts.test.ts
+++ b/test/exit-format-ts.test.ts
@@ -5,7 +5,8 @@ import { Allocation, AllocationType, Exit } from "../src/types";
 describe("ExitFormat (typescript)", function () {
   it("Can encode an allocation", async function () {
     const allocation: Allocation = {
-      destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+      destination:
+        "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
       amount: "0x01",
       allocationType: AllocationType.simple,
       metadata: "0x",
@@ -25,7 +26,8 @@ describe("ExitFormat (typescript)", function () {
         metadata: "0x",
         allocations: [
           {
-            destination: "0x96f7123E3A80C9813eF50213ADEd0e4511CB820f",
+            destination:
+              "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
             amount: "0x01",
             allocationType: AllocationType.simple,
             metadata: "0x",


### PR DESCRIPTION
We didn't catch these when doing #39.

Meta-comment: a cross language solidity/typescript test may have caught this earlier.