### PR TITLE
narrow type for better backwards compatibility

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { BigNumberish } from "@ethersproject/bignumber";
+import { BigNumber } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 
 export enum AllocationType {
@@ -9,8 +9,8 @@ export enum AllocationType {
 
 export interface Allocation {
   destination: string; // an Ethereum address
-  amount: BigNumberish;
-  allocationType: BigNumberish;
+  amount: BigNumber | string | number;
+  allocationType: BigNumber | string | number;
   metadata: BytesLike;
 }
 


### PR DESCRIPTION
In newer versions of ethers (since 5.2.0), the javascript `bigint` type was added to the `BigNumberish` union. This causes an error when we try to pass them into (e.g. typechain) functions that expect an old `BigNumberish` (and therefore don't expect a bigint).