### PR TITLE
Feature: add exits equal

### DIFF
--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -96,10 +96,7 @@ library ExitFormat {
         SingleAssetExit[] memory exitA,
         SingleAssetExit[] memory exitB
     ) internal pure returns (bool) {
-        return _bytesEqual(
-            encodeExit(exitA),
-            encodeExit(exitB)
-        );
+        return _bytesEqual(encodeExit(exitA), encodeExit(exitB));
     }
 
     /**

--- a/contracts/TestConsumer.sol
+++ b/contracts/TestConsumer.sol
@@ -43,11 +43,7 @@ contract TestConsumer {
     function exitsEqual(
         ExitFormat.SingleAssetExit[] memory exitA,
         ExitFormat.SingleAssetExit[] memory exitB
-    )
-        public
-        pure
-        returns (bool)
-    {
+    ) public pure returns (bool) {
         return ExitFormat.exitsEqual(exitA, exitB);
     }
 

--- a/contracts/TestConsumer.sol
+++ b/contracts/TestConsumer.sol
@@ -40,6 +40,17 @@ contract TestConsumer {
         return ExitFormat.decodeAllocation(_allocation_);
     }
 
+    function exitsEqual(
+        ExitFormat.SingleAssetExit[] memory exitA,
+        ExitFormat.SingleAssetExit[] memory exitB
+    )
+        public
+        pure
+        returns (bool)
+    {
+        return ExitFormat.exitsEqual(exitA, exitB);
+    }
+
     function executeSingleAssetExit(
         ExitFormat.SingleAssetExit memory singleAssetExit
     ) public {

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -58,6 +58,49 @@ describe("ExitFormat (solidity)", function () {
     );
   });
 
+  it("Can compare exits for equality", async function () {
+    const allocations: Allocation[] = [
+      {
+        destination:
+          "0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f",
+        amount: "0x01",
+        allocationType: AllocationType.simple,
+        metadata: "0x",
+      },
+    ];
+    
+    const assetA = "0x0000000000000000000000000000000000000000";
+    const assetC = "0x0000000000000000000000000000000000000001";
+
+    const exitA: Exit = [
+      {
+        asset: assetA,
+        metadata: "0x",
+        allocations
+      },
+    ];
+
+    const exitB: Exit = [
+      {
+        asset: assetA,
+        metadata: "0x",
+        allocations
+      },
+    ];
+
+    const exitC: Exit = [
+      {
+        asset: assetC,
+        metadata: "0x",
+        allocations
+      },
+    ];
+    const exitsABequal = await testConsumer.exitsEqual(exitA, exitB);
+    const exitsACequal = await testConsumer.exitsEqual(exitA, exitC);
+    expect(exitsABequal).to.be.true;
+    expect(exitsACequal).to.be.false;
+  });
+
   it("Can execute a single asset exit and a whole exit", async function () {
     const amount = "0x01";
 

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -68,7 +68,7 @@ describe("ExitFormat (solidity)", function () {
         metadata: "0x",
       },
     ];
-    
+
     const assetA = "0x0000000000000000000000000000000000000000";
     const assetC = "0x0000000000000000000000000000000000000001";
 
@@ -76,7 +76,7 @@ describe("ExitFormat (solidity)", function () {
       {
         asset: assetA,
         metadata: "0x",
-        allocations
+        allocations,
       },
     ];
 
@@ -84,7 +84,7 @@ describe("ExitFormat (solidity)", function () {
       {
         asset: assetA,
         metadata: "0x",
-        allocations
+        allocations,
       },
     ];
 
@@ -92,7 +92,7 @@ describe("ExitFormat (solidity)", function () {
       {
         asset: assetC,
         metadata: "0x",
-        allocations
+        allocations,
       },
     ];
     const exitsABequal = await testConsumer.exitsEqual(exitA, exitB);


### PR DESCRIPTION
Add `exitsEqual` method to compare whether exits are equal or not.
Uses encoding and internal `_bytesEqual`.

_Related to [#499 in `go-nitro`](https://github.com/statechannels/go-nitro/issues/499#issuecomment-1091984948)._ 