### PR TITLE
ERC-1155 exits

### DIFF
--- a/contracts/TestConsumer.sol
+++ b/contracts/TestConsumer.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.4;
 
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import "./ExitFormat.sol";
 
-contract TestConsumer {
+contract TestConsumer is ERC1155Holder {
     receive() external payable {
         // contract may receive ether
     }

--- a/contracts/TestERC1155.sol
+++ b/contracts/TestERC1155.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract TestERC1155 is ERC1155 {
+    uint256 public constant TokenA = 123;
+
+    constructor(uint256 initialSupply) ERC1155("") {
+        _mint(msg.sender, TokenA, initialSupply, "");
+    }
+}

--- a/contracts/TestERC20.sol
+++ b/contracts/TestERC20.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract TestERC20 is ERC20 {
+    constructor(uint256 initialSupply) ERC20("TestToken", "TT") {
+        _mint(msg.sender, initialSupply);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./coders";
+export * from "./metadata";

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,14 @@
+import { defaultAbiCoder, ParamType } from "@ethersproject/abi";
+import { BytesLike } from "@ethersproject/bytes";
+
+export enum ExitMetadataType {
+  ERC20,
+  ERC1155,
+}
+
+export function makeERC1155ExitMetadata(tokenId: number): BytesLike {
+  return defaultAbiCoder.encode(
+    ["uint8", "tuple(uint256)"],
+    [ExitMetadataType.ERC1155, [tokenId]]
+  );
+}

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -7,6 +7,7 @@ import {
   Exit,
   SingleAssetExit,
 } from "../src/types";
+import { makeERC1155ExitMetadata } from "../src/metadata";
 import { TestConsumer } from "../typechain/TestConsumer";
 
 describe("ExitFormat (solidity)", function () {
@@ -140,5 +141,78 @@ describe("ExitFormat (solidity)", function () {
     expect(await testConsumer.provider.getBalance(alice.address)).to.equal(
       BigNumber.from(amount).mul(2)
     );
+  });
+
+  it("Can execute a single ERC20 asset exit", async function () {
+    const [alice] = await ethers.getSigners();
+
+    // Alice gets all of the initial minting of tokens
+    let initialSupply = ethers.utils.parseEther((1000).toString());
+    let erc20Token = await (
+      await ethers.getContractFactory("TestERC20", alice)
+    ).deploy(initialSupply);
+    await erc20Token.deployed();
+
+    // Alice transfers all tokens to the TestConsumer
+    await erc20Token.connect(alice).transfer(testConsumer.address, initialSupply);    
+    expect(await erc20Token.balanceOf(alice.address)).to.equal(0);
+    expect(await erc20Token.balanceOf(testConsumer.address)).to.equal(initialSupply);
+
+    // an exit referring to the token contract
+    const singleAssetExit: SingleAssetExit = {
+      asset: erc20Token.address,
+      metadata: "0x",
+      allocations: [
+        {
+          destination: "0x000000000000000000000000" + alice.address.slice(2), // padded alice
+          amount: initialSupply.toString(),
+          allocationType: AllocationType.simple,
+          metadata: "0x",
+        },
+      ],
+    };
+
+    // Use the exit to withdraw the tokens
+    await (await testConsumer.executeSingleAssetExit(singleAssetExit)).wait();
+    expect(await erc20Token.balanceOf(alice.address)).to.equal(initialSupply);
+    expect(await erc20Token.balanceOf(testConsumer.address)).to.equal(0);
+
+  });
+
+  it("Can execute a single ERC1155 asset exit", async function () {
+    const [alice] = await ethers.getSigners();
+    const tokenId = 123;
+
+    // Alice gets all of the initial minting of tokens
+    let initialSupply = ethers.utils.parseEther((1000).toString());
+    let erc1155Collection = await (
+      await ethers.getContractFactory("TestERC1155", alice)
+    ).deploy(initialSupply);
+    await erc1155Collection.deployed();
+
+    // Alice transfers all tokens to the TestConsumer
+    await erc1155Collection.safeTransferFrom(alice.address, testConsumer.address, tokenId, initialSupply, "0x")
+    expect(await erc1155Collection.balanceOf(alice.address, tokenId)).to.equal(0);
+    expect(await erc1155Collection.balanceOf(testConsumer.address, tokenId)).to.equal(initialSupply);
+
+    // an exit referring to the token contract
+    const singleAssetExit: SingleAssetExit = {
+      asset: erc1155Collection.address,
+      metadata: makeERC1155ExitMetadata(tokenId),
+      allocations: [
+        {
+          destination: "0x000000000000000000000000" + alice.address.slice(2), // padded alice
+          amount: initialSupply.toString(),
+          allocationType: AllocationType.simple,
+          metadata: "0x",
+        },
+      ],
+    };
+
+    // Use the exit to withdraw the tokens
+    await (await testConsumer.executeSingleAssetExit(singleAssetExit)).wait();
+    expect(await erc1155Collection.balanceOf(alice.address, tokenId)).to.equal(initialSupply);
+    expect(await erc1155Collection.balanceOf(testConsumer.address, tokenId)).to.equal(0);
+
   });
 });


### PR DESCRIPTION
# Minimum Viable Erc1155 exits

An example for one way other token types (in this case ERC1155) could be supported by using the metadata field.

## Solidity code changes
- The `executeSingleAssetExit` function checks the first byte of the metadata. The value of this byte should instruct as to what kind of exit to perform (as defined in the `ExitMetadataType` enum)
- Adds a `ERC1155ExitMetadata` struct which the function will attempt to interpret the metadata as if it as the magic byte '0x01'. This contains a `tokenId` field which instructs which token in the collection the exit refers to
- Adds logic to perform the ERC1155 exit
- Adds test token contracts (ERC20 and ERC1155)
- Implements `ERC1155Holder` on `TestConsumer` so it can receive 1155 tokens

## Typescript code changes
- Adds a helper function to build ERC1155 exit metadata
- Adds tests for performing ERC20 and ERC1155 token exits

Requesting comments on this approach