### PR TITLE
Allow for fully-qualified assets via `SingleAssetExit.AssetMetaData`

### DIFF
--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -40,7 +40,7 @@ library ExitFormat {
     }
 
     // Enum of different (non-native) token types the SingleAssetExit can contain
-    // Native - The chains native asset (e.g. the one payable functions can receive).
+    // Native - The chain's native asset (e.g. the one payable functions can receive).
     //          This Asset type isn't technically required as native assets are also indicated by using the
     //          zero address in the `asset` field of `SingleAssetExit`.
     // ERC20 - Assets managed by a contract implementing IERC20

--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -50,13 +50,7 @@ library ExitFormat {
     //          This requires the metadata to be an encoded `TokenIdExitMetadata`
     // Qualified - Assets that are fully qualified and pinned to a specific chain and assetHolder.
     //             This requires the metadata to be an encoded `QualifiedAssetMetaData`
-    enum AssetType {
-        Native,
-        ERC20,
-        ERC721,
-        ERC1155,
-        Qualified
-    }
+    enum AssetType {Native, ERC20, ERC721, ERC1155, Qualified}
 
     // Metadata structure for ERC721 and ERC1155 exits
     struct TokenIdExitMetadata {
@@ -68,11 +62,7 @@ library ExitFormat {
     // (which would make a material difference to the final state in the case of running out of gas or funds)
     // Allocations = Allocation[]
 
-    enum AllocationType {
-        simple,
-        withdrawHelper,
-        guarantee
-    }
+    enum AllocationType {simple, withdrawHelper, guarantee}
 
     // An Allocation specifies
     // * a destination, referring either to an ethereum address or an application-specific identifier
@@ -172,11 +162,14 @@ library ExitFormat {
                 _isAddress(singleAssetExit.allocations[j].destination),
                 "Destination is not a zero-padded address"
             );
-            address payable destination = payable(
-                address(
-                    uint160(uint256(singleAssetExit.allocations[j].destination))
-                )
-            );
+            address payable destination =
+                payable(
+                    address(
+                        uint160(
+                            uint256(singleAssetExit.allocations[j].destination)
+                        )
+                    )
+                );
             uint256 amount = singleAssetExit.allocations[j].amount;
             if (asset == address(0)) {
                 (bool success, ) = destination.call{value: amount}(""); //solhint-disable-line avoid-low-level-calls
@@ -192,12 +185,15 @@ library ExitFormat {
                     singleAssetExit.assetMetadata.assetType == AssetType.ERC721
                 ) {
                     require(amount == 1, "Amount must be 1 for an ERC721 exit");
-                    uint256 tokenId = abi
-                        .decode(
-                            singleAssetExit.assetMetadata.metadata,
+                    uint256 tokenId =
+                        abi
+                            .decode(
+                            singleAssetExit
+                                .assetMetadata
+                                .metadata,
                             (TokenIdExitMetadata)
                         )
-                        .tokenId;
+                            .tokenId;
                     IERC721(asset).safeTransferFrom(
                         address(this),
                         destination,
@@ -207,12 +203,15 @@ library ExitFormat {
                     // ERC1155 Token
                     singleAssetExit.assetMetadata.assetType == AssetType.ERC1155
                 ) {
-                    uint256 tokenId = abi
-                        .decode(
-                            singleAssetExit.assetMetadata.metadata,
+                    uint256 tokenId =
+                        abi
+                            .decode(
+                            singleAssetExit
+                                .assetMetadata
+                                .metadata,
                             (TokenIdExitMetadata)
                         )
-                        .tokenId;
+                            .tokenId;
                     IERC1155(asset).safeTransferFrom(
                         address(this),
                         destination,
@@ -228,9 +227,10 @@ library ExitFormat {
                 singleAssetExit.allocations[j].allocationType ==
                 uint8(AllocationType.withdrawHelper)
             ) {
-                WithdrawHelperMetaData memory wd = _parseWithdrawHelper(
-                    singleAssetExit.allocations[j].metadata
-                );
+                WithdrawHelperMetaData memory wd =
+                    _parseWithdrawHelper(
+                        singleAssetExit.allocations[j].metadata
+                    );
                 WithdrawHelper(wd.callTo).execute(wd.callData, amount);
             }
         }
@@ -247,10 +247,11 @@ library ExitFormat {
     {
         // All unqualified assets are local by assumption.
         if (singleAssetExit.assetMetadata.assetType == AssetType.Qualified) {
-            QualifiedAssetMetaData memory pin = abi.decode(
-                singleAssetExit.assetMetadata.metadata,
-                (QualifiedAssetMetaData)
-            );
+            QualifiedAssetMetaData memory pin =
+                abi.decode(
+                    singleAssetExit.assetMetadata.metadata,
+                    (QualifiedAssetMetaData)
+                );
 
             require(
                 pin.chainID == block.chainid,
@@ -305,36 +306,36 @@ library ExitFormat {
 
             // if lengths don't match the arrays are not equal
             switch eq(length, mload(_postBytes))
-            case 1 {
-                // cb is a circuit breaker in the for loop since there's
-                //  no said feature for inline assembly loops
-                // cb = 1 - don't breaker
-                // cb = 0 - break
-                let cb := 1
+                case 1 {
+                    // cb is a circuit breaker in the for loop since there's
+                    //  no said feature for inline assembly loops
+                    // cb = 1 - don't breaker
+                    // cb = 0 - break
+                    let cb := 1
 
-                let mc := add(_preBytes, 0x20)
-                let end := add(mc, length)
+                    let mc := add(_preBytes, 0x20)
+                    let end := add(mc, length)
 
-                for {
-                    let cc := add(_postBytes, 0x20)
-                    // the next line is the loop condition:
-                    // while(uint256(mc < end) + cb == 2)
-                } eq(add(lt(mc, end), cb), 2) {
-                    mc := add(mc, 0x20)
-                    cc := add(cc, 0x20)
-                } {
-                    // if any of these checks fails then arrays are not equal
-                    if iszero(eq(mload(mc), mload(cc))) {
-                        // unsuccess:
-                        success := 0
-                        cb := 0
+                    for {
+                        let cc := add(_postBytes, 0x20)
+                        // the next line is the loop condition:
+                        // while(uint256(mc < end) + cb == 2)
+                    } eq(add(lt(mc, end), cb), 2) {
+                        mc := add(mc, 0x20)
+                        cc := add(cc, 0x20)
+                    } {
+                        // if any of these checks fails then arrays are not equal
+                        if iszero(eq(mload(mc), mload(cc))) {
+                            // unsuccess:
+                            success := 0
+                            cb := 0
+                        }
                     }
                 }
-            }
-            default {
-                // unsuccess:
-                success := 0
-            }
+                default {
+                    // unsuccess:
+                    success := 0
+                }
         }
         /* solhint-disable no-inline-assembly */
 

--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -249,15 +249,15 @@ library ExitFormat {
         returns (bool)
     {
         if (singleAssetExit.assetMetadata.assetType == AssetType.Qualified) {
-            QualifiedAssetMetaData memory pin =
+            QualifiedAssetMetaData memory expectedLocation =
                 abi.decode(
                     singleAssetExit.assetMetadata.metadata,
                     (QualifiedAssetMetaData)
                 );
 
             return
-                pin.chainID != block.chainid ||
-                pin.assetHolder != address(this);
+                expectedLocation.chainID != block.chainid ||
+                expectedLocation.assetHolder != address(this);
         } else {
             // All unqualified assets are local by assumption.
             return false;

--- a/contracts/ExitFormat.sol
+++ b/contracts/ExitFormat.sol
@@ -40,17 +40,15 @@ library ExitFormat {
     }
 
     // Enum of different (non-native) token types the SingleAssetExit can contain
-    // Native - The chain's native asset (e.g. the one payable functions can receive).
-    //          This Asset type isn't technically required as native assets are also indicated by using the
-    //          zero address in the `asset` field of `SingleAssetExit`.
-    // ERC20 - Assets managed by a contract implementing IERC20
+    // Default - Either an ERC20 token or the chain's native asset, specified by
+    //           the oken address 0x00. Requires no metadata.
     // ERC721 - NFT assets managed by a contract implementing IERC721.
     //          This requires the metadata to be an encoded `TokenIdExitMetadata`
     // ERC1155 - Fungible or non-fungible assets managed by a contract implementing IERC1155.
     //          This requires the metadata to be an encoded `TokenIdExitMetadata`
     // Qualified - Assets that are fully qualified and pinned to a specific chain and assetHolder.
     //             This requires the metadata to be an encoded `QualifiedAssetMetaData`
-    enum AssetType {Native, ERC20, ERC721, ERC1155, Qualified}
+    enum AssetType {Default, ERC721, ERC1155, Qualified}
 
     // Metadata structure for ERC721 and ERC1155 exits
     struct TokenIdExitMetadata {
@@ -179,7 +177,7 @@ library ExitFormat {
             } else {
                 if (
                     // ERC20 Token
-                    singleAssetExit.assetMetadata.assetType == AssetType.ERC20
+                    singleAssetExit.assetMetadata.assetType == AssetType.Default
                 ) {
                     IERC20(asset).transfer(destination, amount);
                 } else if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,7 @@ export interface SingleAssetExit {
 }
 
 export enum AssetType {
-  Native,
-  ERC20,
+  Default,
   ERC721,
   ERC1155,
   Qualified,
@@ -38,7 +37,7 @@ export interface QualifiedAssetMetaData {
 }
 
 export const NullAssetMetadata: AssetMetadata = {
-  assetType: AssetType.Native,
+  assetType: AssetType.Default,
   metadata: "0x",
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,11 +24,17 @@ export enum AssetType {
   ERC20,
   ERC721,
   ERC1155,
+  Qualified,
 }
 
 export interface AssetMetadata {
   assetType: AssetType;
   metadata: BytesLike;
+}
+
+export interface QualifiedAssetMetaData {
+  chainID: string; // a uint256
+  assetHolder: string; // an Ethereum address
 }
 
 export const NullAssetMetadata: AssetMetadata = {

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -12,7 +12,13 @@ import {
 import { makeTokenIdExitMetadata } from "../src/token-id-metadata";
 import { TestConsumer } from "../typechain/TestConsumer";
 import { makeSimpleExit } from "./test-helpers";
-import { deployERC20, deployERC721, deployERC1155 } from "./test-helpers";
+import {
+  deployERC20,
+  deployERC721,
+  deployERC1155,
+  getQualifiedSAE,
+} from "./test-helpers";
+import { AbiCoder, defaultAbiCoder } from "ethers/lib/utils";
 
 describe("ExitFormat (solidity)", function () {
   let testConsumer: TestConsumer;
@@ -360,6 +366,63 @@ describe("ExitFormat (solidity)", function () {
     );
     expect(await erc1155Collection.balanceOf(alice.address, tokenBId)).to.equal(
       initialSupply
+    );
+  });
+
+  it("Correctly interprets qualified assets", async function () {
+    const amount = "0x01";
+
+    // deposit some native asset into the test consumer
+    await testConsumer.signer.sendTransaction({
+      to: testConsumer.address,
+      value: BigNumber.from(amount).toHexString(),
+    });
+
+    const alice = new Wallet(
+      "0x68d3e3134e2b3488ad249233f8fa77ea040bbb6434ea28e4acde7db08200000a"
+    );
+
+    // Note: correct chainID is 31337 (default hardhat chainID)
+    //       correct asset holder address is testConsumer.address
+
+    const badChainID = getQualifiedSAE(
+      1, // eth mainnet
+      testConsumer.address,
+      alice.address,
+      amount
+    );
+    await expect(
+      testConsumer.executeSingleAssetExit(badChainID)
+    ).to.be.revertedWith("Qualified asset must be on this chain");
+    expect(await testConsumer.provider.getBalance(alice.address)).to.equal(
+      "0x00"
+    );
+
+    const badAssetHolderAddress = getQualifiedSAE(
+      31337,
+      alice.address, // alice's address is not the asset holder's address
+      alice.address,
+      amount
+    );
+    await expect(
+      testConsumer.executeSingleAssetExit(badAssetHolderAddress)
+    ).to.be.revertedWith("Qualified asset must be held by this contract");
+    expect(await testConsumer.provider.getBalance(alice.address)).to.equal(
+      "0x00"
+    );
+
+    const correctlyQualifiedLocalAsset = getQualifiedSAE(
+      31337,
+      testConsumer.address,
+      alice.address,
+      amount
+    );
+
+    await (
+      await testConsumer.executeSingleAssetExit(correctlyQualifiedLocalAsset)
+    ).wait();
+    expect(await testConsumer.provider.getBalance(alice.address)).to.equal(
+      amount
     );
   });
 });

--- a/test/exit-format-sol.test.ts
+++ b/test/exit-format-sol.test.ts
@@ -175,7 +175,7 @@ describe("ExitFormat (solidity)", function () {
       destination: alice.address,
       amount: initialSupply,
       assetMetadata: {
-        assetType: AssetType.ERC20,
+        assetType: AssetType.Default,
         metadata: "0x",
       },
     });

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -87,14 +87,14 @@ export async function deployERC1155(deployer: any, initialSupply: number) {
  *
  * @param chainId The qualified asset's chain ID
  * @param assetHolder the qualified asset's asset holder contract address
- * @param destination the recipient of the asset
+ * @param address the recipient of the asset
  * @param amount the amount of the asset to transfer
  * @returns
  */
 export function getQualifiedSAE(
   chainId: number,
   assetHolder: string,
-  destination: string,
+  address: string,
   amount: string
 ): SingleAssetExit {
   return {
@@ -108,7 +108,7 @@ export function getQualifiedSAE(
     },
     allocations: [
       {
-        destination: "0x000000000000000000000000" + destination.slice(2),
+        destination: "0x000000000000000000000000" + address.slice(2),
         amount,
         allocationType: AllocationType.simple,
         metadata: "0x",

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -5,9 +5,10 @@ import {
   SingleAssetExit,
   AllocationType,
   NullAssetMetadata,
+  AssetType,
 } from "../src/types";
 
-import { Result } from "@ethersproject/abi";
+import { defaultAbiCoder, Result } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 
@@ -78,4 +79,40 @@ export async function deployERC1155(deployer: any, initialSupply: number) {
   ).deploy(initialSupply);
   await erc1155Collection.deployed();
   return erc1155Collection;
+}
+
+/**
+ * Constructs a single asset exit pinned to the given chainID and assetHolder address.
+ * The asset is the native asset of the chain.
+ *
+ * @param chainId The qualified asset's chain ID
+ * @param assetHolder the qualified asset's asset holder contract address
+ * @param destination the recipient of the asset
+ * @param amount the amount of the asset to transfer
+ * @returns
+ */
+export function getQualifiedSAE(
+  chainId: number,
+  assetHolder: string,
+  destination: string,
+  amount: string
+): SingleAssetExit {
+  return {
+    asset: "0x0000000000000000000000000000000000000000",
+    assetMetadata: {
+      assetType: AssetType.Qualified,
+      metadata: defaultAbiCoder.encode(
+        ["uint chainID", "address assetHolder"],
+        [chainId, assetHolder]
+      ),
+    },
+    allocations: [
+      {
+        destination: "0x000000000000000000000000" + destination.slice(2),
+        amount,
+        allocationType: AllocationType.simple,
+        metadata: "0x",
+      },
+    ],
+  };
 }


### PR DESCRIPTION
This PR enables cross-chain accounting. IE,specifying assets across multiple EVM compatible distributed ledgers (Ethereum, Arbitrum, FVM, etc etc).

Questions:
- in this PR, a singleAssetExit reverts when a qualified asset is not local to the executing contract. Should it fail silently instead? Case: `executeExit` will always revert when an outcome spans multiple asset holders. Countercase: silent failure seems pretty passive. Middle ground: emit some event and fail?
- with this PR, assets are qualified at the singleAssetExit level. Is there a case for applying the same metadata to individual allocations instead of to the asset?

Future work:
- this PR does not allow for fully qualified assets which are of type EIP-721 (nft) or EIP-1155 (multitoken standard). New combined types could be created to accommodate this. (eg, AssetType.Qualified721).