### PR TITLE
version bump...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statechannels/exit-format",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Standard Exit Format for L2s built on EVM chains",
   "repository": "https://github.com/statechannels/exit-format.git",
   "author": "geoknee <georgeknee@googlemail.com>",


### PR DESCRIPTION
minor version bump because of added functionality (qualified assets). Publishing to reimport iawefnto go-nitro with intent to trial cross-chain functionality.

Current version  on npm is now [0.2.0](https://www.npmjs.com/package/@statechannels/exit-format)